### PR TITLE
Update Camel to 3.4.0 Release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ projectVersion=0.42.0
 supportedJavaVersion=1.8
 
 # framework verions
-camelVersion=3.3.0
+camelVersion=3.4.0
 jacksonVersion=2.11.0
 junitVersion=5.6.2
 

--- a/src/main/java/com/linuxforhealth/connect/builder/LinuxForHealthRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/LinuxForHealthRouteBuilder.java
@@ -13,7 +13,7 @@ import org.apache.camel.builder.RouteBuilder;
  * Provides convenience methods for resolving application property values and route generation.
  * This class is concrete rather than abstract due to Camel's route scanning mechanism.
  */
-public class LinuxForHealthRouteBuilder extends RouteBuilder {
+public abstract class LinuxForHealthRouteBuilder extends RouteBuilder {
 
     /**
      * @return {@link EndpointUriBuilder} used to build endpoint uris for consumers and producers
@@ -23,7 +23,4 @@ public class LinuxForHealthRouteBuilder extends RouteBuilder {
                 .getRegistry()
                 .lookupByNameAndType(EndpointUriBuilder.BEAN_NAME, EndpointUriBuilder.class);
     }
-
-    @Override
-    public void configure() {}
 }


### PR DESCRIPTION
This PR updates Linux For Health's Camel dependency to the 3.4.0 release.

The primary motivation for this update is to utilize a patch we provided for Camel's route builder scanning algorithm. This patch allows us to declare our LinuxForHealthRouteBuilder class as abstract.

Other Camel related changes are available [here](https://camel.apache.org/releases/release-3.4.0/)