### PR TITLE
Add Avalon docker-compose files

### DIFF
--- a/container-support/compose/docker-compose-pool-sgx.yaml
+++ b/container-support/compose/docker-compose-pool-sgx.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.5'
+
+services:
+
+  avalon-kme:
+    container_name: avalon-kme
+    image: avalon-sgx-enclave-manager-kme-dev
+    build:
+      args:
+        - SGX_MODE=HW
+    volumes:
+      # Map aesm service on host to docker, required only in HW mode.
+      - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
+    devices:
+      - "/dev/isgx:/dev/isgx"
+
+  avalon-enclave-manager:
+    container_name: avalon-wpe
+    image: avalon-sgx-enclave-manager-wpe-dev
+    build:
+      args:
+        - SGX_MODE=HW
+    volumes:
+      # Map aesm service on host to docker, required only in HW mode.
+      - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
+    devices:
+      - "/dev/isgx:/dev/isgx"
+

--- a/container-support/compose/docker-compose-pool.yaml
+++ b/container-support/compose/docker-compose-pool.yaml
@@ -1,0 +1,95 @@
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.5'
+
+volumes:
+  # Named volume for WPE to share MRENCLAVE with KME. MRENCLAVE value can also be passed
+  # as a command line parameter (using the option --wpe_mr_enclave) to KME enclave manger.
+  # Then the MRENCLAVE value stored in file "wpe_mr_enclave.txt" in shared volume will be
+  # overridden by the value passed in command line.
+  pool-1:
+
+services:
+
+  avalon-kme:
+    container_name: avalon-kme
+    image: avalon-enclave-manager-kme-dev
+    build:
+      context: .
+      dockerfile: ./enclave_manager/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+        - ENCLAVE_TYPE=kme
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    volumes:
+      - pool-1:/shared-pool-1
+    expose:
+      # KME listener port
+      - 1948
+    command: |
+      bash -c "
+        while true;
+          do
+            if [ -e /shared-pool-1/wpe_mr_enclave.txt ];
+              then mv /shared-pool-1/wpe_mr_enclave.txt /project/avalon/wpe_mr_enclave.txt;
+              break;
+            fi;
+            sleep 1;
+        done;
+        enclave_manager --lmdb_url http://avalon-lmdb:9090 --bind http://avalon-kme:1948
+        tail -f /dev/null
+      "
+    depends_on:
+      - avalon-lmdb
+      - avalon-listener
+
+  avalon-enclave-manager:
+    container_name: avalon-wpe
+    image: avalon-enclave-manager-wpe-dev
+    build:
+      context: .
+      dockerfile: ./enclave_manager/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+        - ENCLAVE_TYPE=wpe
+        # Configure list of workload that need to be supported
+        # by this WPE by separating each workload by delimiter semicolon.
+        - WORKLOADS=echo-result;heart-disease-eval;inside-out-eval;simple-wallet
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    volumes:
+      - pool-1:/shared-pool-1
+    expose:
+      # ZMQ socket port.
+      - 5555
+    command: |
+      bash -c "
+        mv /project/avalon/wpe_mr_enclave.txt /shared-pool-1
+        enclave_manager --lmdb_url http://avalon-lmdb:9090 --kme_listener_url http://avalon-kme:1948
+        tail -f /dev/null
+      "
+    depends_on:
+      - avalon-lmdb
+      - avalon-listener
+      - avalon-kme

--- a/container-support/compose/docker-compose-sgx.yaml
+++ b/container-support/compose/docker-compose-sgx.yaml
@@ -1,0 +1,28 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.5'
+
+services:
+  avalon-enclave-manager:
+    image: avalon-sgx-enclave-manager-dev
+    build:
+      args:
+        - SGX_MODE=HW
+    volumes:
+      # Map aesm service on host to docker, required only in HW mode.
+      - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
+    devices:
+      - "/dev/isgx:/dev/isgx"
+

--- a/container-support/compose/docker-compose-singleton.yaml
+++ b/container-support/compose/docker-compose-singleton.yaml
@@ -1,0 +1,120 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.5'
+
+services:
+  avalon-shell:
+    container_name: avalon-shell
+    image: avalon-shell-dev
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      args:
+        - DISPLAY=${DISPLAY:-}
+        - XAUTHORITY=~/.Xauthority
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - DISPLAY
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    volumes:
+      # Below volume mappings are required for DISPLAY settings by heart disease GUI client
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ~/.Xauthority:/root/.Xauthority
+    command: |
+      bash -c "tail -f /dev/null"
+    stop_signal: SIGKILL
+    depends_on:
+      - avalon-enclave-manager
+      - avalon-listener
+
+  avalon-enclave-manager:
+    container_name: avalon-enclave-manager
+    image: avalon-enclave-manager-dev
+    build:
+      context: .
+      dockerfile: ./enclave_manager/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+        - ENCLAVE_TYPE=singleton
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      # ZMQ socket port.
+      - 5555
+    command: |
+      bash -c "
+        enclave_manager --lmdb_url http://avalon-lmdb:9090
+        tail -f /dev/null
+      "
+    depends_on:
+      - avalon-lmdb
+
+  avalon-lmdb:
+    container_name: avalon-lmdb
+    image: avalon-lmdb-dev
+    build:
+      context: .
+      dockerfile: ./shared_kv_storage/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      # Port is where lmdb server will listen for http request.
+      # Port should be same as in bind parameter or lmdb_config.toml
+      - 9090
+    command: |
+      bash -c "
+        kv_storage --bind http://avalon-lmdb:9090
+        tail -f /dev/null
+      "
+
+  avalon-listener:
+    container_name: avalon-listener
+    image: avalon-listener-dev
+    build:
+      context: .
+      dockerfile: ./listener/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    expose:
+      - 1947
+      # ZMQ socket port.
+      - 5555
+    command: |
+      bash -c "
+        avalon_listener --bind http://avalon-listener:1947 --lmdb_url http://avalon-lmdb:9090
+        tail -f /dev/null
+        "
+    depends_on:
+      - avalon-lmdb


### PR DESCRIPTION
add docker-compose files for SGX configuration, worker pool standup with one administrator node and one worker node utilizing SGX, and worker pool standup with one administrator node and one worker node utilizing simulated SGX.