### PR TITLE
Integrating Kafka and Zookeeper UBI containers 

### DIFF
--- a/container-support/compose/docker-compose.override
+++ b/container-support/compose/docker-compose.override
@@ -1,0 +1,36 @@
+# This override file is used to include the Linux for Health container
+# Additional services are reconfigured as necessary so that Linux for Health can resolve services using
+# the docker compose network, when running within a container.
+#
+# To include Linux For Health in the compose stack rename this file to docker-compose.override.yml and execute:
+# cd container-support/compose
+# docker-compose up -d
+version: "3.7"
+services:
+  lfh:
+    restart: "always"
+    image: docker.io/linuxforhealth/connect:0.46.0-beta
+    ports:
+      - "2575:2575"
+      - "8080:8080"
+    volumes:
+      - ${PWD}/application.properties:/opt/lfh/config/application.properties
+    depends_on:
+      - "kafka"
+      - "nats-server"
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    restart: "always"
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "kafka:9092"
+  kafka:
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENERS: "INTERNAL://kafka:9092"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"

--- a/container-support/compose/docker-compose.yml
+++ b/container-support/compose/docker-compose.yml
@@ -1,30 +1,33 @@
 version: "3.7"
 services:
+  zookeeper:
+    image: docker.io/linuxforhealth/zookeeper-standalone:3.6.1
+    ports:
+      - "2181:2181"
   kafdrop:
     image: obsidiandynamics/kafdrop
-    restart: "no"
+    restart: "always"
     ports:
       - "9000:9000"
     environment:
-      KAFKA_BROKERCONNECT: "kafka:29092"
+      KAFKA_BROKERCONNECT: "kafka:9094"
       JVM_OPTS: "-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
     depends_on:
       - "kafka"
   kafka:
-    image: obsidiandynamics/kafka
-    restart: "no"
+    image: docker.io/linuxforhealth/kafka-standalone:2.5.0
+    restart: "always"
     ports:
-      - "2181:2181"
       - "9092:9092"
+      - "9094:9094"
     environment:
-      KAFKA_LISTENERS: "INTERNAL://:29092,EXTERNAL://:9092"
-      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:29092,EXTERNAL://localhost:9092"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENERS: "INTERNAL://kafka:9094,EXTERNAL://kafka:9092"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:9094,EXTERNAL://localhost:9092"
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
       KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
-      KAFKA_ZOOKEEPER_SESSION_TIMEOUT: "6000"
-      KAFKA_RESTART_ATTEMPTS: "10"
-      KAFKA_RESTART_DELAY: "5"
-      ZOOKEEPER_AUTOPURGE_PURGE_INTERVAL: "0"
+    depends_on:
+      - "zookeeper"
   nats-server:
     image: linuxforhealth/nats-server:2.1.7
     container_name: nats-server

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,6 +24,7 @@
     Adjust the loggers below for the desired granularity
     -->
     <logger name="com.linuxforhealth.connect" level="debug" />
+    <logger name="org.apache.camel" level="debug" />
     <logger name="org.apache.camel.main" level="info" />
     <logger name="org.apache.kafka.consumer" level="warn" />
 


### PR DESCRIPTION
This PR updates LFH connect's docker compose configuration to support the new Kafka and Zookeeper UBI containers. I also updated the LFH logback config to set "camel" to debug.