### PR TITLE
Integrating Image Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - USER_ID: The USER ID used for the non-privileged "application" account. Set in base image.
 # - JAVA_HOME: The Java installation directory. Set in base image.
 # - JAVA_OPTIONS: Java command line options used to configure the JVM. Set in base image.
 
@@ -29,7 +28,6 @@ RUN mkdir -p /opt/lfh/libs
 COPY --from=builder /tmp/lfh /opt/lfh/
 
 ENV APP_ROOT=${APP_ROOT}
-ENV USER_ID=${USER_ID}
 ENV JAVA_HOME=${JAVA_HOME}
 ENV JAVA_OPTIONS=${JAVA_OPTIONS}
 

--- a/container-support/compose/docker-compose.override
+++ b/container-support/compose/docker-compose.override
@@ -7,19 +7,8 @@
 # docker-compose up -d
 version: "3.7"
 services:
-  lfh:
-    restart: "always"
-    image: docker.io/linuxforhealth/connect:0.46.0-beta
-    ports:
-      - "2575:2575"
-      - "8080:8080"
-    volumes:
-      - ${PWD}/application.properties:/opt/lfh/config/application.properties
-    depends_on:
-      - "kafka"
-      - "nats-server"
   kafdrop:
-    image: obsidiandynamics/kafdrop
+    image: docker.io/obsidiandynamics/kafdrop
     restart: "always"
     ports:
       - "9000:9000"
@@ -34,3 +23,14 @@ services:
       KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092"
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT"
       KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+  lfh:
+    restart: "always"
+    image: docker.io/linuxforhealth/connect:0.47.0-beta
+    ports:
+      - "2575:2575"
+      - "8080:8080"
+    volumes:
+      - ${PWD}/application.properties:/opt/lfh/config/application.properties
+    depends_on:
+      - "kafka"
+      - "nats-server"

--- a/container-support/compose/docker-compose.yml
+++ b/container-support/compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "2181:2181"
   kafdrop:
-    image: obsidiandynamics/kafdrop
+    image: docker.io/obsidiandynamics/kafdrop
     restart: "always"
     ports:
       - "9000:9000"
@@ -29,7 +29,7 @@ services:
     depends_on:
       - "zookeeper"
   nats-server:
-    image: linuxforhealth/nats-server:2.1.7
+    image: docker.io/linuxforhealth/nats-server:2.1.7
     container_name: nats-server
     ports:
       - 4222:4222

--- a/src/main/java/com/linuxforhealth/connect/App.java
+++ b/src/main/java/com/linuxforhealth/connect/App.java
@@ -91,7 +91,7 @@ public final class App {
             String absolutePath = path.toAbsolutePath().toString();
             logger.info("loading properties from file:{}", absolutePath);
             camelMain.setDefaultPropertyPlaceholderLocation("file:" + absolutePath);
-            pc.setLocation(absolutePath);
+            pc.setLocation("file:" + absolutePath);
         } else {
             properties.load(ClassLoader.getSystemResourceAsStream(App.APPLICATION_PROPERTIES_FILE_NAME));
             logger.info("loading properties from classpath:{}", App.APPLICATION_PROPERTIES_FILE_NAME);


### PR DESCRIPTION
This PR integrates recent LFH image updates with LFH connect. Specifically, the USER_ID environment variables was removed from the LFH base image, resulting in a rebuild of all downstream images.

Updates include:
- Incrementing version of LFH to 0.47.0-beta
- resolved an additional issue with loading properties from an "override" location, which is currently used in docker compose