### PR TITLE
LFH connect image updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,16 +27,10 @@ LABEL description="Provides Route Based Processing for Inbound Data Flows"
 RUN mkdir -p /opt/lfh/libs
 COPY --from=builder /tmp/lfh /opt/lfh/
 
-ENV APP_ROOT=${APP_ROOT}
-ENV JAVA_HOME=${JAVA_HOME}
-ENV JAVA_OPTIONS=${JAVA_OPTIONS}
-
-# MLLP
-EXPOSE 2575
-# REST
-EXPOSE 8080
+# expose MLLP, REST
+EXPOSE 2575 8080
 
 WORKDIR ${APP_ROOT}
-USER 1001
+USER lfh
 
 CMD ["sh", "-c", "java -XX:+UseContainerSupport ${JAVA_OPTS} -jar linux-for-health-connect.jar"]

--- a/container-support/compose/docker-compose.override
+++ b/container-support/compose/docker-compose.override
@@ -25,7 +25,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
   lfh:
     restart: "always"
-    image: docker.io/linuxforhealth/connect:0.47.0-beta
+    image: docker.io/linuxforhealth/connect:0.48.0-beta
     ports:
       - "2575:2575"
       - "8080:8080"


### PR DESCRIPTION
This PR updates our LFH connect image to:

- remove redundant ENV variable assignments
- streamline the use of the EXPOSE command
- use ENV variables consistently within the image