### PR TITLE
Use valid encrypted placeholder key for ACD

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ linuxforhealth.connect.endpoint.fhir_r4_rest.baseUri=http://0.0.0.0:8080/fhir/r4
 linuxforhealth.connect.endpoint.acd_rest.baseUri=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api
 linuxforhealth.connect.endpoint.acd_rest.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow
 linuxforhealth.connect.endpoint.acd_rest.version=2020-07-01
-linuxforhealth.connect.endpoint.acd_rest.key=ENC(YOUR_JASYPT_ENCRYPTED_KEY)
+linuxforhealth.connect.endpoint.acd_rest.key=ENC(3XsVRVv9eVphHv+CAm2sGkwKvltlrkhqBOFVXiYO89btdklYEsdu0w==)
 
 # Blue Button 2.0 REST
 linuxforhealth.connect.endpoint.bluebutton_20_rest.authorizeUri=http://0.0.0.0:8080/bluebutton/authorize

--- a/src/test/resources/route-validation-tests/fhir-to-acd.properties
+++ b/src/test/resources/route-validation-tests/fhir-to-acd.properties
@@ -3,4 +3,4 @@
 linuxforhealth.connect.endpoint.acd_rest.baseUri=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api
 linuxforhealth.connect.endpoint.acd_rest.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow
 linuxforhealth.connect.endpoint.acd_rest.version=2020-07-01
-linuxforhealth.connect.endpoint.acd_rest.key=ENC(YOUR_JASYPT_ENCRYPTED_KEY)
+linuxforhealth.connect.endpoint.acd_rest.key=ENC(3XsVRVv9eVphHv+CAm2sGkwKvltlrkhqBOFVXiYO89btdklYEsdu0w==)


### PR DESCRIPTION
Update the ACD placeholder key to be a valid encrypted key.
**Note:** this key will not actually work with ACD. It's just a placeholder.
Anyone can provision a free instance of ACD though for test/evaluation purposes.
Just replace the `linuxforhealth.connect.endpoint.acd_rest.key` property value with your valid, Jasypt-encryped apikey.