### PR TITLE
add errexit nounset pipefail to oci scripts

### DIFF
--- a/container-support/oci/remove.sh
+++ b/container-support/oci/remove.sh
@@ -2,6 +2,10 @@
 # remove.sh
 # removes the LFH network and containers
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # load environment variables from compose stack and the oci tools
 source ../compose/.env
 source .env

--- a/container-support/oci/start.sh
+++ b/container-support/oci/start.sh
@@ -2,6 +2,10 @@
 # start.sh
 # starts Linux for Health OCI containers
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # load environment variables from compose stack and the oci tools
 source ../compose/.env
 source .env


### PR DESCRIPTION
errexit  = exit should any value not return success
nounset = don't allow running with unitialized vars
pipefail = fail from any failure of a piped command, not just the last command