### PR TITLE
Support LFH Environment Variables for Application Settings

### DIFF
--- a/container-support/compose/application.properties
+++ b/container-support/compose/application.properties
@@ -1,9 +1,0 @@
-# Linux for Health data store
-lfh.connect.dataStore.uri={{lfh.connect.dataStore.host}}:<topicName>?brokers=kafka:9092
-
-# Linux for Health messaging
-lfh.connect.messaging.uri=nats:lfh-events?servers=nats-server:4222
-lfh.connect.messaging.subscribe.hosts=nats-server:4222
-
-# Orthanc DICOM server
-lfh.connect.orthanc_server.uri=http://orthanc:{{lfh.connect.orthanc_server.port}}/instances

--- a/container-support/compose/docker-compose.server.yml
+++ b/container-support/compose/docker-compose.server.yml
@@ -1,14 +1,17 @@
 version: "3.7"
 services:
   lfh:
-    image: ${LFH_CONNECT_IMAGE}
+    image: "docker.io/linuxforhealth/connect:test"
     restart: "always"
+    environment:
+      LFH_CONNECT_DATASTORE_URI: "{{lfh.connect.datastore.host}}:<topicName>?brokers=kafka:9092"
+      LFH_CONNECT_MESSAGING_URI: "nats:lfh-events?servers=nats-server:4222"
+      LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS: "nats-server:4222"
+      LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:{{lfh.connect.orthanc_server.port}}/instances"
     ports:
       - ${LFH_CONNECT_MLLP_PORT}:${LFH_CONNECT_MLLP_PORT}
       - ${LFH_CONNECT_REST_PORT}:${LFH_CONNECT_REST_PORT}
       - ${LFH_CONNECT_HTTP_PORT}:${LFH_CONNECT_HTTP_PORT}
-    volumes:
-      - ${PWD}/application.properties:/opt/lfh/config/application.properties
     depends_on:
       - "kafka"
       - "nats-server"

--- a/container-support/compose/docker-compose.server.yml
+++ b/container-support/compose/docker-compose.server.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   lfh:
-    image: "docker.io/linuxforhealth/connect:test"
+    image: ${LFH_CONNECT_IMAGE}
     restart: "always"
     environment:
       LFH_CONNECT_DATASTORE_URI: "{{lfh.connect.datastore.host}}:<topicName>?brokers=kafka:9092"

--- a/container-support/oci/start.sh
+++ b/container-support/oci/start.sh
@@ -94,16 +94,16 @@ is_ready localhost "${LFH_KAFDROP_PORT}"
 echo "launch lfh connect"
 ${OCI_COMMAND} pull "${LFH_CONNECT_IMAGE}"
 
-HOST_VOLUME_DIR=$(dirname "${PWD}")/compose
-echo "mounting application.properties from ${HOST_VOLUME_DIR}"
-
 ${OCI_COMMAND} run -d \
               --network "${LFH_NETWORK_NAME}" \
               --name "${LFH_CONNECT_SERVICE_NAME}" \
               -p "${LFH_CONNECT_MLLP_PORT}":"${LFH_CONNECT_MLLP_PORT}" \
               -p "${LFH_CONNECT_REST_PORT}":"${LFH_CONNECT_REST_PORT}" \
               -p "${LFH_CONNECT_HTTP_PORT}":"${LFH_CONNECT_HTTP_PORT}" \
-              -v "${HOST_VOLUME_DIR}"/application.properties:/opt/lfh/config/application.properties \
+              --env LFH_CONNECT_DATASTORE_URI="{{lfh.connect.datastore.host}}:<topicName>?brokers=kafka:9092" \
+              --env LFH_CONNECT_MESSAGING_URI="nats:lfh-events?servers=nats-server:4222" \
+              --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
+              --env LFH_CONNECT_ORTHANC_SERVER_URI="http://orthanc:{{lfh.connect.orthanc_server.port}}/instances" \
               "${LFH_CONNECT_IMAGE}"
 
 is_ready localhost "${LFH_CONNECT_MLLP_PORT}"

--- a/src/main/java/com/linuxforhealth/connect/App.java
+++ b/src/main/java/com/linuxforhealth/connect/App.java
@@ -33,6 +33,7 @@ public final class App {
 
     private final static String APPLICATION_PROPERTIES_FILE_NAME = "application.properties";
     private final static String EXTERNAL_PROPERTY_FILE_PATH = "config/application.properties";
+    private final static String ENV_NAMESPACE = "lfh_connect_";
     private final static String BEAN_PROPERTY_NAMESPACE = "lfh.connect.bean";
     private final static String ROUTE_BUILDER_PACKAGE = "com.linuxforhealth.connect.builder";
 
@@ -65,10 +66,55 @@ public final class App {
     }
 
     /**
-     * Loads application properties.
+     * Loads properties from a well known external location in {@link App#EXTERNAL_PROPERTY_FILE_PATH}
+     * @return {@link Properties} object
+     * @throws IOException if an error occurs reading the properties from file
+     */
+    private Properties loadExternalProperties() throws IOException {
+        Path externalPropertyPath = Paths.get(App.EXTERNAL_PROPERTY_FILE_PATH);
+        Properties externalProperties = new Properties();
+
+        if (Files.exists(externalPropertyPath)) {
+            String absolutePath = externalPropertyPath.toAbsolutePath().toString();
+            logger.info("loading override properties from file:{}", absolutePath);
+            externalProperties.load(Files.newInputStream(externalPropertyPath));
+        }
+        return externalProperties;
+    }
+
+    /**
+     * Loads property settings from environment variables.
+     * Properties are translated from environment variable names and values.
+     * @return {@link Properties} object.
+     */
+    private Properties loadEnvironmentProperties() {
+        Properties envProperties = new Properties();
+
+        System.getenv()
+                .entrySet()
+                .stream()
+                .filter(e -> e.getKey().toLowerCase().startsWith(ENV_NAMESPACE))
+                .forEach(e -> {
+                    String key = e.getKey().toLowerCase().replaceAll("_", ".");
+                    String value = e.getValue();
+                    envProperties.put(key, value);
+                });
+
+        return envProperties;
+    }
+
+    /**
+     * Loads application properties from the classpath, external file, and environment variables.
      *
-     * Properties are loaded from the classpath and may be overridden using an external file located in
-     * config/application.properties.
+     * Properties are resolved in the following order:
+     * <ul>
+     *     <li>classpath</li>
+     *     <li>external file</li>
+     *     <li>environment variables</li>
+     * </ul>
+     *
+     * Environment variables are translated to a valid "property" format.
+     * Example: LFH_CONNECT_FOO=bar is translated to lfh.connect.foo=bar.
      *
      * Properties are registered with the camel context and returned from this method for bootstrap processing.
      * This "double-evaluation" is required as the app has to configure some components prior to the camel context
@@ -85,21 +131,17 @@ public final class App {
         logger.info("loading properties from classpath:{}", App.APPLICATION_PROPERTIES_FILE_NAME);
         camelPropertiesComponent.setLocation("classpath:" + App.APPLICATION_PROPERTIES_FILE_NAME);
 
-        Path externalPropertyPath = Paths.get(App.EXTERNAL_PROPERTY_FILE_PATH);
+        Properties externalProperties = loadExternalProperties();
+        camelPropertiesComponent.setOverrideProperties(externalProperties);
+        externalProperties.forEach((k, v) -> {
+            properties.setProperty(k.toString(), v.toString());
+        });
 
-        if (Files.exists(externalPropertyPath)) {
-            String absolutePath = externalPropertyPath.toAbsolutePath().toString();
-            logger.info("loading override properties from file:{}", absolutePath);
-
-            Properties overrideProperties = new Properties();
-            overrideProperties.load(Files.newInputStream(externalPropertyPath));
-            camelPropertiesComponent.setOverrideProperties(overrideProperties);
-
-            // set override properties
-            overrideProperties.forEach((k, v) -> {
-                properties.setProperty(k.toString(), v.toString());
-            });
-        }
+        Properties envProperties = loadEnvironmentProperties();
+        camelPropertiesComponent.setOverrideProperties(envProperties);
+        envProperties.forEach((k, v) -> {
+            properties.setProperty(k.toString(), v.toString());
+        });
 
         return properties;
     }

--- a/src/main/java/com/linuxforhealth/connect/builder/AcdAnalyzeRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/AcdAnalyzeRouteBuilder.java
@@ -51,7 +51,7 @@ public class AcdAnalyzeRouteBuilder extends BaseRouteBuilder {
 
 			// ACD request pre-conditions
 
-			.when(isPropertyNotSet("lfh.connect.acd_rest.baseUri"))
+			.when(isPropertyNotSet("lfh.connect.acd_rest.baseuri"))
 				.log(LoggingLevel.WARN, logger, "ACD service endpoint not configured - message will not be processed")
 				.stop()
 

--- a/src/main/java/com/linuxforhealth/connect/builder/BaseRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/BaseRouteBuilder.java
@@ -36,8 +36,8 @@ public abstract class BaseRouteBuilder extends RouteBuilder {
 
         Arrays.asList(
                 propertyNamespace + ".uri",
-                propertyNamespace + ".dataFormat",
-                propertyNamespace + ".messageType"
+                propertyNamespace + ".dataformat",
+                propertyNamespace + ".messagetype"
         ).forEach(ctxSupport::getProperty);
     }
 

--- a/src/main/java/com/linuxforhealth/connect/builder/BlueButton20RestRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/BlueButton20RestRouteBuilder.java
@@ -53,22 +53,22 @@ public class BlueButton20RestRouteBuilder extends RouteBuilder {
     private void addAuthorizationRoute() {
         // Blue Button OAuth2 - Authorize route in Blue Button 2.0 & get code
         CamelContextSupport contextSupport = new CamelContextSupport(getContext());
-        URI blueButtonAuthorizeUri = URI.create(contextSupport.getProperty("lfh.connect.bluebutton_20.authorizeUri"));
+        URI blueButtonAuthorizeUri = URI.create(contextSupport.getProperty("lfh.connect.bluebutton_20.authorizeuri"));
         rest(blueButtonAuthorizeUri.getPath())
             .get()
             .route()
             .routeId(AUTHORIZE_ROUTE_ID)
             .process(exchange -> {
                 String callbackURL = SimpleBuilder
-                        .simple("${properties:lfh.connect.bluebutton_20.handlerUri}")
+                        .simple("${properties:lfh.connect.bluebutton_20.handleruri}")
                         .evaluate(exchange, String.class);
 
                 String cmsAuthorizeURL = SimpleBuilder
-                        .simple("${properties:lfh.connect.bluebutton_20.cms.authorizeUri}")
+                        .simple("${properties:lfh.connect.bluebutton_20.cms.authorizeuri}")
                         .evaluate(exchange, String.class);
 
                 String clientId = SimpleBuilder
-                        .simple("${properties:lfh.connect.bluebutton_20.cms.clientId}")
+                        .simple("${properties:lfh.connect.bluebutton_20.cms.clientid}")
                         .evaluate(exchange, String.class);
 
                 // Set up call to redirect to Blue Button API so the user can authenticate this application
@@ -102,7 +102,7 @@ public class BlueButton20RestRouteBuilder extends RouteBuilder {
     private void addCallbackRoute() {
         // Blue Button OAuth2 - Callback to exchange code for token (displayed in the browser)
         CamelContextSupport contextSupport = new CamelContextSupport(getContext());
-        URI blueButtonHandlerUri = URI.create(contextSupport.getProperty("lfh.connect.bluebutton_20.handlerUri"));
+        URI blueButtonHandlerUri = URI.create(contextSupport.getProperty("lfh.connect.bluebutton_20.handleruri"));
         URI cmsTokenURL = URI.create(contextSupport.getProperty("lfh.connect.bluebutton_20.cms.tokenUri"));
         rest(blueButtonHandlerUri.getPath())
                 .get()
@@ -110,10 +110,10 @@ public class BlueButton20RestRouteBuilder extends RouteBuilder {
                 .routeId(CALLBACK_ROUTE_ID)
                 .process(exchange -> {
 
-                    String clientId = SimpleBuilder.simple("${properties:lfh.connect.bluebutton_20.cms.clientId}")
+                    String clientId = SimpleBuilder.simple("${properties:lfh.connect.bluebutton_20.cms.clientid}")
                             .evaluate(exchange, String.class);
 
-                    String clientSecret = SimpleBuilder.simple("${properties:lfh.connect.bluebutton_20.cms.clientSecret}")
+                    String clientSecret = SimpleBuilder.simple("${properties:lfh.connect.bluebutton_20.cms.clientsecret}")
                             .evaluate(exchange, String.class);
 
                     // Setting up call to Blue Button 2.0 to exchange the code for a token
@@ -149,7 +149,7 @@ public class BlueButton20RestRouteBuilder extends RouteBuilder {
 
                 String resourceType = exchange.getIn().getHeader("resource", String.class).toUpperCase();
 
-                String kafkaDataStoreUri = SimpleBuilder.simple("${properties:lfh.connect.dataStore.uri}")
+                String kafkaDataStoreUri = SimpleBuilder.simple("${properties:lfh.connect.datastore.uri}")
                         .evaluate(exchange, String.class)
                         .replaceAll("<topicName>", "FHIR-R4_" + resourceType);
 
@@ -168,7 +168,7 @@ public class BlueButton20RestRouteBuilder extends RouteBuilder {
             })
             .doTry()
             .process(exchange -> {
-                String cmsBaseURI = SimpleBuilder.simple("${properties:lfh.connect.bluebutton_20.cms.baseUri}")
+                String cmsBaseURI = SimpleBuilder.simple("${properties:lfh.connect.bluebutton_20.cms.baseuri}")
                         .evaluate(exchange, String.class);
 
                 // Set up Blue Button 2.0 query
@@ -199,7 +199,7 @@ public class BlueButton20RestRouteBuilder extends RouteBuilder {
                     // Set the message attributes for data format back to r3 and change the Kafka queue
                     String resourceType = exchange.getProperty("resourceType", String.class).toUpperCase();
 
-                    String kafkaDataStoreUri = SimpleBuilder.simple("${properties:lfh.connect.dataStore.uri}")
+                    String kafkaDataStoreUri = SimpleBuilder.simple("${properties:lfh.connect.datastore.uri}")
                             .evaluate(exchange, String.class)
                             .replaceAll("<topicName>", "FHIR-R3_" + resourceType);
 

--- a/src/main/java/com/linuxforhealth/connect/processor/MetaDataProcessor.java
+++ b/src/main/java/com/linuxforhealth/connect/processor/MetaDataProcessor.java
@@ -88,16 +88,16 @@ public final class MetaDataProcessor implements Processor {
 
         exchange.setProperty("routeUri", routeUri);
 
-        String dataFormatExpression = "${properties:" + routePropertyNamespace + ".dataFormat}";
+        String dataFormatExpression = "${properties:" + routePropertyNamespace + ".dataformat}";
         exchange.setProperty("dataFormat", parseSimpleExpression(dataFormatExpression, exchange).toUpperCase());
 
-        String messageTypeExpression = "${properties:" + routePropertyNamespace + ".messageType}";
+        String messageTypeExpression = "${properties:" + routePropertyNamespace + ".messagetype}";
         exchange.setProperty("messageType", parseSimpleExpression(messageTypeExpression, exchange).toUpperCase());
 
         String topicName = exchange.getProperty("dataFormat") + "_" + exchange.getProperty("messageType");
 
         exchange.setProperty("dataStoreUri",
-                parseSimpleExpression("${properties:lfh.connect.dataStore.uri}", exchange)
+                parseSimpleExpression("${properties:lfh.connect.datastore.uri}", exchange)
                 .replaceAll("<topicName>", topicName));
 
         String exchangeBody = exchange.getIn().getBody(String.class);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,24 +3,24 @@ lfh.connect.bean.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFa
 lfh.connect.bean.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory
 lfh.connect.hl7_v2_mllp.host=0.0.0.0:2575
 lfh.connect.hl7_v2_mllp.uri=netty:tcp://{{lfh.connect.hl7_v2_mllp.host}}?sync=true&encoders=#hl7encoder&decoders=#hl7decoder
-lfh.connect.hl7_v2_mllp.dataFormat=hl7-v2
-lfh.connect.hl7_v2_mllp.messageType=\${header.CamelHL7MessageType}
+lfh.connect.hl7_v2_mllp.dataformat=hl7-v2
+lfh.connect.hl7_v2_mllp.messagetype=\${header.CamelHL7MessageType}
 
 # FHIR R4 REST
 lfh.connect.fhir_r4_rest.host=0.0.0.0
 lfh.connect.fhir_r4_rest.port=8080
 lfh.connect.fhir_r4_rest.uri=http://{{lfh.connect.fhir_r4_rest.host}}:{{lfh.connect.fhir_r4_rest.port}}/fhir/r4
-lfh.connect.fhir_r4_rest.dataFormat=fhir-r4
-lfh.connect.fhir_r4_rest.messageType=\${header.resource}
+lfh.connect.fhir_r4_rest.dataformat=fhir-r4
+lfh.connect.fhir_r4_rest.messagetype=\${header.resource}
 
 lfh.connect.acd_rest.auth=authMethod=Basic&authUsername=apikey&authPassword=ENC(3XsVRVv9eVphHv+CAm2sGkwKvltlrkhqBOFVXiYO89btdklYEsdu0w==)
 lfh.connect.acd_rest.version=2020-07-01
 lfh.connect.acd_rest.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow
 lfh.connect.acd_rest.host=us-east.wh-acd.cloud.ibm.com
-lfh.connect.acd_rest.baseUri=https://{{lfh.connect.acd_rest.host}}
-lfh.connect.acd_rest.uri={{lfh.connect.acd_rest.baseUri}}/wh-acd/api/v1/analyze/{{lfh.connect.acd_rest.flow}}?version={{lfh.connect.acd_rest.version}}&{{lfh.connect.acd_rest.auth}}
-lfh.connect.acd_rest.dataFormat=ACD
-lfh.connect.acd_rest.messageType=INSIGHTS
+lfh.connect.acd_rest.baseuri=https://{{lfh.connect.acd_rest.host}}
+lfh.connect.acd_rest.uri={{lfh.connect.acd_rest.baseuri}}/wh-acd/api/v1/analyze/{{lfh.connect.acd_rest.flow}}?version={{lfh.connect.acd_rest.version}}&{{lfh.connect.acd_rest.auth}}
+lfh.connect.acd_rest.dataformat=ACD
+lfh.connect.acd_rest.messagetype=INSIGHTS
 
 # Blue Button 2.0 REST
 # Blue Button Camel endpoint (listening endpoint/consumer)
@@ -31,33 +31,33 @@ lfh.connect.bluebutton_20.rest.uri=http://{{lfh.connect.bluebutton_20.rest.host}
 # Blue Button OAuth2 Callbacks
 lfh.connect.bluebutton_20.callback.host=localhost
 lfh.connect.bluebutton_20.callback.port=8080
-lfh.connect.bluebutton_20.callback.baseUri={{lfh.connect.bluebutton_20.callback.host}}:{{lfh.connect.bluebutton_20.callback.port}}
-lfh.connect.bluebutton_20.authorizeUri=http://{{lfh.connect.bluebutton_20.callback.baseUri}}/bluebutton/authorize
-lfh.connect.bluebutton_20.handlerUri=http://{{lfh.connect.bluebutton_20.callback.baseUri}}/bluebutton/handler
+lfh.connect.bluebutton_20.callback.baseuri={{lfh.connect.bluebutton_20.callback.host}}:{{lfh.connect.bluebutton_20.callback.port}}
+lfh.connect.bluebutton_20.authorizeuri=http://{{lfh.connect.bluebutton_20.callback.baseuri}}/bluebutton/authorize
+lfh.connect.bluebutton_20.handleruri=http://{{lfh.connect.bluebutton_20.callback.baseuri}}/bluebutton/handler
 
 # Blue Button CMS Endpoints
 lfh.connect.bluebutton_20.cms.host=sandbox.bluebutton.cms.gov
-lfh.connect.bluebutton_20.cms.authorizeUri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/o/authorize/
+lfh.connect.bluebutton_20.cms.authorizeuri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/o/authorize/
 lfh.connect.bluebutton_20.cms.tokenUri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/o/token/
-lfh.connect.bluebutton_20.cms.baseUri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/fhir/
-lfh.connect.bluebutton_20.cms.clientId=ENC(MLI1vy+555l8RitLxQguke+EMnxAXTi/J15jHXcVSA4m3LapXkQ2SDjD/eXCfe729jvLAezHrHc=)
-lfh.connect.bluebutton_20.cms.clientSecret=ENC(LVddmNBkdgHTPxewJsd/ji9i36omfi9o+pBCu8aWr1HZ3CynQHR4n9lVaueats/OcupwNYiGW028/cTDP/MDU8Fe0ov2eLx8YDRPQzyimhRQSG+xPD5hqvjRCbQNsoSTC+hPe+VMdKRE+Oup6R12h3mDYOZ3BJF8heoiee2zR9obGyF+E08pmEI0BYqoKFYG)
+lfh.connect.bluebutton_20.cms.baseuri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/fhir/
+lfh.connect.bluebutton_20.cms.clientid=ENC(MLI1vy+555l8RitLxQguke+EMnxAXTi/J15jHXcVSA4m3LapXkQ2SDjD/eXCfe729jvLAezHrHc=)
+lfh.connect.bluebutton_20.cms.clientsecret=ENC(LVddmNBkdgHTPxewJsd/ji9i36omfi9o+pBCu8aWr1HZ3CynQHR4n9lVaueats/OcupwNYiGW028/cTDP/MDU8Fe0ov2eLx8YDRPQzyimhRQSG+xPD5hqvjRCbQNsoSTC+hPe+VMdKRE+Oup6R12h3mDYOZ3BJF8heoiee2zR9obGyF+E08pmEI0BYqoKFYG)
 
 # Orthanc DICOM
 lfh.connect.orthanc.host=0.0.0.0
 lfh.connect.orthanc.port=9090
 lfh.connect.orthanc.uri=jetty:http://{{lfh.connect.orthanc.host}}:{{lfh.connect.orthanc.port}}/orthanc/instances?httpMethodRestrict=POST&enableMultipartFilter=true
 lfh.connect.orthanc.rest.uri=http://{{lfh.connect.orthanc.host}}:{{lfh.connect.orthanc.port}}/orthanc/instances?httpMethodRestrict=POST&enableMultipartFilter=true
-lfh.connect.orthanc.dataFormat=dicom
-lfh.connect.orthanc.messageType=Image
+lfh.connect.orthanc.dataformat=dicom
+lfh.connect.orthanc.messagetype=Image
 lfh.connect.orthanc_server.host=localhost
 lfh.connect.orthanc_server.port=8042
 lfh.connect.orthanc_server.uri=http://{{lfh.connect.orthanc_server.host}}:{{lfh.connect.orthanc_server.port}}/instances
 
 # Linux for Health data store
 lfh.connect.bean.kafka=org.apache.camel.component.kafka.KafkaComponent
-lfh.connect.dataStore.host=kafka
-lfh.connect.dataStore.uri={{lfh.connect.dataStore.host}}:<topicName>?brokers=localhost:9094
+lfh.connect.datastore.host=kafka
+lfh.connect.datastore.uri={{lfh.connect.datastore.host}}:<topicName>?brokers=localhost:9094
 
 # Linux for Health messaging
 lfh.connect.bean.nats=org.apache.camel.component.nats.NatsComponent

--- a/src/test/java/com/linuxforhealth/connect/builder/BaseRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/BaseRouteTest.java
@@ -30,8 +30,8 @@ public class BaseRouteTest extends CamelTestSupport {
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         Properties props = new Properties();
         props.setProperty("lfh.connect.default.uri", "direct:start");
-        props.setProperty("lfh.connect.default.dataFormat", "csv");
-        props.setProperty("lfh.connect.default.messageType", "person");
+        props.setProperty("lfh.connect.default.dataformat", "csv");
+        props.setProperty("lfh.connect.default.messagetype", "person");
         return props;
     }
 

--- a/src/test/java/com/linuxforhealth/connect/builder/BlueButton20ApiTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/BlueButton20ApiTest.java
@@ -34,8 +34,8 @@ public class BlueButton20ApiTest extends RouteTestSupport {
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientId", "client-id");
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientSecret", "client-secret");
+        props.setProperty("lfh.connect.bluebutton_20.cms.clientid", "client-id");
+        props.setProperty("lfh.connect.bluebutton_20.cms.clientsecret", "client-secret");
         return props;
     }
 

--- a/src/test/java/com/linuxforhealth/connect/builder/BlueButton20AuthTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/BlueButton20AuthTest.java
@@ -28,7 +28,7 @@ public class BlueButton20AuthTest extends RouteTestSupport {
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientId", "client-id");
+        props.setProperty("lfh.connect.bluebutton_20.cms.clientid", "client-id");
         return props;
     }
 
@@ -61,7 +61,7 @@ public class BlueButton20AuthTest extends RouteTestSupport {
 
         mockResult.expectedPropertyReceived("location", expectedLocation);
 
-        fluentTemplate.to("{{lfh.connect.bluebutton_20.authorizeUri}}")
+        fluentTemplate.to("{{lfh.connect.bluebutton_20.authorizeuri}}")
                 .send();
 
         mockResult.assertIsSatisfied();

--- a/src/test/java/com/linuxforhealth/connect/builder/BlueButton20CallbackTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/BlueButton20CallbackTest.java
@@ -31,8 +31,8 @@ public class BlueButton20CallbackTest extends RouteTestSupport {
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
         props.setProperty("lfh.connect.bluebutton_20.cms.tokenUri", "https://sandbox.bluebutton.cms.gov/v1/o/token/");
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientId", "client-id");
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientSecret", "client-secret");
+        props.setProperty("lfh.connect.bluebutton_20.cms.clientid", "client-id");
+        props.setProperty("lfh.connect.bluebutton_20.cms.clientsecret", "client-secret");
         return props;
     }
 
@@ -66,7 +66,7 @@ public class BlueButton20CallbackTest extends RouteTestSupport {
         mockResult.expectedHeaderReceived("Content-Type", "application/x-www-form-urlencoded");
         mockResult.expectedHeaderReceived("Content-Length", expectedBody.length());
 
-        fluentTemplate.to("{{lfh.connect.bluebutton_20.handlerUri}}")
+        fluentTemplate.to("{{lfh.connect.bluebutton_20.handleruri}}")
                 .withHeader("code", "auth-code")
                 .send();
 

--- a/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthErrorTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthErrorTest.java
@@ -32,10 +32,10 @@ public class LinuxForHealthErrorTest extends RouteTestSupport {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
 
         props.setProperty("lfh.connect.test.uri", "direct:test-error");
-        props.setProperty("lfh.connect.test.dataFormat", "csv");
-        props.setProperty("lfh.connect.test.messageType", "person");
+        props.setProperty("lfh.connect.test.dataformat", "csv");
+        props.setProperty("lfh.connect.test.messagetype", "person");
 
-        props.setProperty("lfh.connect.dataStore.uri", "mock:data-store");
+        props.setProperty("lfh.connect.datastore.uri", "mock:data-store");
         props.setProperty("lfh.connect.messaging.uri", "mock:messaging");
         return props;
     }

--- a/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthNotifyTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthNotifyTest.java
@@ -34,8 +34,8 @@ public class LinuxForHealthNotifyTest extends RouteTestSupport {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
 
         props.setProperty("lfh.connect.test.uri", "direct:test-notify");
-        props.setProperty("lfh.connect.test.dataFormat", "csv");
-        props.setProperty("lfh.connect.test.messageType", "person");
+        props.setProperty("lfh.connect.test.dataformat", "csv");
+        props.setProperty("lfh.connect.test.messagetype", "person");
 
         props.setProperty("lfh.connect.messaging.uri", "mock:messaging");
         return props;

--- a/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthStoreAndNotifyTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthStoreAndNotifyTest.java
@@ -31,10 +31,10 @@ public class LinuxForHealthStoreAndNotifyTest extends RouteTestSupport {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
 
         props.setProperty("lfh.connect.test.uri", "direct:test-store-notify");
-        props.setProperty("lfh.connect.test.dataFormat", "csv");
-        props.setProperty("lfh.connect.test.messageType", "person");
+        props.setProperty("lfh.connect.test.dataformat", "csv");
+        props.setProperty("lfh.connect.test.messagetype", "person");
 
-        props.setProperty("lfh.connect.dataStore.uri", "mock:data-store");
+        props.setProperty("lfh.connect.datastore.uri", "mock:data-store");
         props.setProperty("lfh.connect.messaging.uri", "mock:messaging");
         return props;
     }
@@ -60,7 +60,7 @@ public class LinuxForHealthStoreAndNotifyTest extends RouteTestSupport {
                                 .routeId("test-store-notify")
                                 .process(exchange -> {
                                     String dataStoreUri = SimpleBuilder
-                                            .simple("${properties:lfh.connect.dataStore.uri}")
+                                            .simple("${properties:lfh.connect.datastore.uri}")
                                             .evaluate(exchange, String.class);
                                     exchange.setProperty("dataStoreUri", dataStoreUri);
                                 })

--- a/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthStoreTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthStoreTest.java
@@ -36,10 +36,10 @@ public class LinuxForHealthStoreTest extends RouteTestSupport {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
 
         props.setProperty("lfh.connect.test.uri", "direct:test-store");
-        props.setProperty("lfh.connect.test.dataFormat", "csv");
-        props.setProperty("lfh.connect.test.messageType", "person");
+        props.setProperty("lfh.connect.test.dataformat", "csv");
+        props.setProperty("lfh.connect.test.messagetype", "person");
 
-        props.setProperty("lfh.connect.dataStore.uri", "mock:data-store");
+        props.setProperty("lfh.connect.datastore.uri", "mock:data-store");
         props.setProperty("lfh.connect.messaging.uri", "mock:messaging");
         return props;
     }
@@ -71,7 +71,7 @@ public class LinuxForHealthStoreTest extends RouteTestSupport {
                                     exchange.setProperty("status", "success");
 
                                     String dataStoreUri = SimpleBuilder
-                                            .simple("${properties:lfh.connect.dataStore.uri}")
+                                            .simple("${properties:lfh.connect.datastore.uri}")
                                             .evaluate(exchange, String.class);
                                     exchange.setProperty("dataStoreUri", dataStoreUri);
 

--- a/src/test/java/com/linuxforhealth/connect/processor/MetaDataProcessorTest.java
+++ b/src/test/java/com/linuxforhealth/connect/processor/MetaDataProcessorTest.java
@@ -32,10 +32,10 @@ class MetaDataProcessorTest extends CamelTestSupport {
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         Properties props = new Properties();
-        props.setProperty("lfh.connect.dataStore.uri", "kafka:<topicName>?brokers=localhost:9094");
+        props.setProperty("lfh.connect.datastore.uri", "kafka:<topicName>?brokers=localhost:9094");
         props.setProperty("lfh.connect.meta.uri", "direct:start");
-        props.setProperty("lfh.connect.meta.dataFormat", "csv");
-        props.setProperty("lfh.connect.meta.messageType", "person");
+        props.setProperty("lfh.connect.meta.dataformat", "csv");
+        props.setProperty("lfh.connect.meta.messagetype", "person");
         return props;
     }
 


### PR DESCRIPTION
This PR updates the LFH property loader algorithm to evaluate environment variables. Environment variables are evaluated as the last step in the “property loading process”, and are translated to a valid LFH property setting.

  Example: LFH_CONNECT_FOO=bar is translated to lfh.connect.foo=bar  

Updates to support this change include:

- the "external" application.properties file used with docker compose and the OCI integrated services is removed
- application.properties keys are now comprised of lower-case characters 
- code which evaluates property keys is updated to utilize lower-case
- integrated container functionality
- server stack profile and oci utilize environment variables rather than an external properties file

I tested these changes with the "server stack" (docker compose) and the OCI script.