### PR TITLE
Convert direct acd-analyze route to rest

### DIFF
--- a/src/main/java/com/linuxforhealth/connect/builder/AcdAnalyzeRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/AcdAnalyzeRouteBuilder.java
@@ -42,50 +42,52 @@ public class AcdAnalyzeRouteBuilder extends BaseRouteBuilder {
 
 	@Override
 	protected void buildRoute(String routePropertyNamespace) {
-		from(ACD_ANALYZE_CONSUMER_URI)
-		.routeId(ACD_ANALYZE_ROUTE_ID)
-		.log(LoggingLevel.DEBUG, logger, "Received message body: ${body}")
-		.log(LoggingLevel.DEBUG, logger, "Received message content-type: ${header.content-type}")
+		
+		rest("/acd")
+			.post("/analyze")
+			.route()
+			.routeId(ACD_ANALYZE_ROUTE_ID)
+			.log(LoggingLevel.DEBUG, logger, "Received message content-type: ${header.content-type}")
 
-		.choice()
-
-			// ACD request pre-conditions
-
-			.when(isPropertyNotSet("lfh.connect.acd_rest.baseUri"))
-				.log(LoggingLevel.WARN, logger, "ACD service endpoint not configured - message will not be processed")
-				.stop()
-
-			.when(isPropertyNotSet("lfh.connect.acd_rest.version"))
-				.log(LoggingLevel.WARN, logger, "ACD service annotator flow not configured - message will not be processed")
-				.stop()
-
-			.when(isPropertyNotSet("lfh.connect.acd_rest.flow"))
-				.log(LoggingLevel.WARN, logger, "ACD service version param not configured - message will not be processed")
-				.stop()
-
-			.when(isPropertyNotSet("lfh.connect.acd_rest.auth"))
-				.log(LoggingLevel.WARN, logger, "ACD service authentication not configured - message will not be processed")
-				.stop()
-
-			.when(header("content-type").isNull())
-				.log(LoggingLevel.WARN, logger, "ACD request content-type header not set in previous route - message will not be processed")
-				.stop()
-
-			.when(isInvalidContentType)
-				.log(LoggingLevel.WARN, logger, "Invalid ACD content-type: ${in.header.content-type}. Only text/plain or application/json is supported - - message will not be processed")
-				.stop()
-
-			.otherwise() // Cleared to make ACD request
-				.setHeader(Exchange.HTTP_METHOD, constant("POST")) // POST /analyze/{flow_id}
-				.to("{{lfh.connect.acd_rest.uri}}")
-				.id(ACD_ANALYZE_REQUEST_PRODUCER_ID)
-				.log(LoggingLevel.DEBUG, logger, "ACD response code: ${header.CamelHttpResponseCode}")
-				.unmarshal().json()
-				.log(LoggingLevel.DEBUG, logger, "ACD response message body: ${body}")
-				.process(new MetaDataProcessor(getRoutePropertyNamespace()))
-				.to(LinuxForHealthRouteBuilder.STORE_AND_NOTIFY_CONSUMER_URI)
-				.id(ACD_ANALYZE_PRODUCER_ID)
-				.stop()
-		.end();
+			.choice()
+	
+				// ACD request pre-conditions
+	
+				.when(isPropertyNotSet("lfh.connect.acd_rest.baseUri"))
+					.log(LoggingLevel.WARN, logger, "ACD service endpoint not configured - message will not be processed")
+					.stop()
+	
+				.when(isPropertyNotSet("lfh.connect.acd_rest.version"))
+					.log(LoggingLevel.WARN, logger, "ACD service annotator flow not configured - message will not be processed")
+					.stop()
+	
+				.when(isPropertyNotSet("lfh.connect.acd_rest.flow"))
+					.log(LoggingLevel.WARN, logger, "ACD service version param not configured - message will not be processed")
+					.stop()
+	
+				.when(isPropertyNotSet("lfh.connect.acd_rest.auth"))
+					.log(LoggingLevel.WARN, logger, "ACD service authentication not configured - message will not be processed")
+					.stop()
+	
+				.when(header("content-type").isNull())
+					.log(LoggingLevel.WARN, logger, "ACD request content-type header not set in previous route - message will not be processed")
+					.stop()
+	
+				.when(isInvalidContentType)
+					.log(LoggingLevel.WARN, logger, "Invalid ACD content-type: ${in.header.content-type}. Only text/plain or application/json is supported - - message will not be processed")
+					.stop()
+	
+				.otherwise() // Cleared to make ACD request
+					.setHeader(Exchange.HTTP_METHOD, constant("POST")) // POST /analyze/{flow_id}
+					.to("{{lfh.connect.acd_rest.uri}}")
+					.id(ACD_ANALYZE_REQUEST_PRODUCER_ID)
+					.log(LoggingLevel.DEBUG, logger, "ACD response code: ${header.CamelHttpResponseCode}")
+					.unmarshal().json()
+					.log(LoggingLevel.DEBUG, logger, "ACD response message body: ${body}")
+					.process(new MetaDataProcessor(getRoutePropertyNamespace()))
+					.to(LinuxForHealthRouteBuilder.STORE_AND_NOTIFY_CONSUMER_URI)
+					.id(ACD_ANALYZE_PRODUCER_ID)
+					.stop()
+			.end();
 	}
 }

--- a/src/main/java/com/linuxforhealth/connect/processor/FhirR4ToAcdProcessor.java
+++ b/src/main/java/com/linuxforhealth/connect/processor/FhirR4ToAcdProcessor.java
@@ -72,7 +72,7 @@ public class FhirR4ToAcdProcessor implements Processor {
 			docEx.getIn().setHeader(Exchange.CONTENT_TYPE, "text/plain");
 			
 			ProducerTemplate pt = exchange.getContext().createProducerTemplate();
-			pt.send("direct:acd-analyze", docEx);
+			pt.send("http:{{lfh.connect.acd_rest.route_host}}:{{lfh.connect.acd_rest.route_port}}/acd/analyze", docEx);
 		}
 		
 	}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,9 +18,11 @@ lfh.connect.acd_rest.version=2020-07-01
 lfh.connect.acd_rest.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow
 lfh.connect.acd_rest.host=us-east.wh-acd.cloud.ibm.com
 lfh.connect.acd_rest.baseUri=https://{{lfh.connect.acd_rest.host}}
-lfh.connect.acd_rest.uri={{lfh.connect.acd_rest.baseUri}}/wh-acd/api/v1/analyze/{{lfh.connect.acd_rest.flow}}?version={{lfh.connect.acd_rest.version}}&{{lfh.connect.acd_rest.auth}}
+lfh.connect.acd_rest.uri={{lfh.connect.acd_rest.baseUri}}/wh-acd/api/v1/analyze/{{lfh.connect.acd_rest.flow}}?version={{lfh.connect.acd_rest.version}}&{{lfh.connect.acd_rest.auth}}&bridgeEndpoint=true&authenticationPreemptive=true
 lfh.connect.acd_rest.dataFormat=ACD
 lfh.connect.acd_rest.messageType=INSIGHTS
+lfh.connect.acd_rest.route_host=0.0.0.0
+lfh.connect.acd_rest.route_port=8080
 
 # Blue Button 2.0 REST
 # Blue Button Camel endpoint (listening endpoint/consumer)


### PR DESCRIPTION
Converted the direct `acs-analyze` route to rest and updated the FHIR to ACD processor to make a rest call to this route.