### PR TITLE
Resolve Issues With Environment Variable to App Property Translation

### DIFF
--- a/src/main/java/com/linuxforhealth/connect/builder/AcdAnalyzeRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/AcdAnalyzeRouteBuilder.java
@@ -38,7 +38,7 @@ public class AcdAnalyzeRouteBuilder extends BaseRouteBuilder {
 	Predicate isPropertyNotSet(String propertyName) { return simple("${properties:" + propertyName + "} == ''"); }
 
 	@Override
-	protected String getRoutePropertyNamespace() {return "lfh.connect.acd_rest";}
+	protected String getRoutePropertyNamespace() {return "lfh.connect.acd";}
 
 	@Override
 	protected void buildRoute(String routePropertyNamespace) {
@@ -51,19 +51,19 @@ public class AcdAnalyzeRouteBuilder extends BaseRouteBuilder {
 
 			// ACD request pre-conditions
 
-			.when(isPropertyNotSet("lfh.connect.acd_rest.baseuri"))
+			.when(isPropertyNotSet("lfh.connect.acd.baseuri"))
 				.log(LoggingLevel.WARN, logger, "ACD service endpoint not configured - message will not be processed")
 				.stop()
 
-			.when(isPropertyNotSet("lfh.connect.acd_rest.version"))
+			.when(isPropertyNotSet("lfh.connect.acd.version"))
 				.log(LoggingLevel.WARN, logger, "ACD service annotator flow not configured - message will not be processed")
 				.stop()
 
-			.when(isPropertyNotSet("lfh.connect.acd_rest.flow"))
+			.when(isPropertyNotSet("lfh.connect.acd.flow"))
 				.log(LoggingLevel.WARN, logger, "ACD service version param not configured - message will not be processed")
 				.stop()
 
-			.when(isPropertyNotSet("lfh.connect.acd_rest.auth"))
+			.when(isPropertyNotSet("lfh.connect.acd.auth"))
 				.log(LoggingLevel.WARN, logger, "ACD service authentication not configured - message will not be processed")
 				.stop()
 
@@ -77,7 +77,7 @@ public class AcdAnalyzeRouteBuilder extends BaseRouteBuilder {
 
 			.otherwise() // Cleared to make ACD request
 				.setHeader(Exchange.HTTP_METHOD, constant("POST")) // POST /analyze/{flow_id}
-				.to("{{lfh.connect.acd_rest.uri}}")
+				.to("{{lfh.connect.acd.uri}}")
 				.id(ACD_ANALYZE_REQUEST_PRODUCER_ID)
 				.log(LoggingLevel.DEBUG, logger, "ACD response code: ${header.CamelHttpResponseCode}")
 				.unmarshal().json()

--- a/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
@@ -13,20 +13,20 @@ import java.net.URI;
 /**
  * Defines a FHIR R4 REST Processing route
  */
-public class FhirR4RestRouteBuilder extends BaseRouteBuilder {
+public class FhirR4RouteBuilder extends BaseRouteBuilder {
 
-    public final static String ROUTE_ID = "fhir-r4-rest";
-    public final static String ROUTE_PRODUCER_ID = "fhir-r4-rest-producer-store-and-notify";
+    public final static String ROUTE_ID = "fhir-r4";
+    public final static String ROUTE_PRODUCER_ID = "fhir-r4-producer-store-and-notify";
 
     @Override
     protected String getRoutePropertyNamespace() {
-        return "lfh.connect.fhir_r4_rest";
+        return "lfh.connect.fhir-r4";
     }
 
     @Override
     protected void buildRoute(String routePropertyNamespace) {
         CamelContextSupport contextSupport = new CamelContextSupport(getContext());
-        URI fhirBaseUri = URI.create(contextSupport.getProperty("lfh.connect.fhir_r4_rest.uri"));
+        URI fhirBaseUri = URI.create(contextSupport.getProperty("lfh.connect.fhir-r4.uri"));
 
         restConfiguration()
                 .host(fhirBaseUri.getHost())

--- a/src/main/java/com/linuxforhealth/connect/builder/Hl7v2RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/Hl7v2RouteBuilder.java
@@ -10,11 +10,11 @@ import com.linuxforhealth.connect.processor.MetaDataProcessor;
 /**
  * Defines a HL7 V2 MLLP processing route
  */
-public class Hl7v2MllpRouteBuilder extends BaseRouteBuilder {
+public class Hl7v2RouteBuilder extends BaseRouteBuilder {
 
-    public final static String ROUTE_ID = "hl7-v2-mllp";
-    public final static String ROUTE_PRODUCER_ID="hl7-v2-mllp-producer";
-    private final static String ROUTE_PROPERTY_NAMESPACE = "lfh.connect.hl7_v2_mllp";
+    public final static String ROUTE_ID = "hl7-v2";
+    public final static String ROUTE_PRODUCER_ID="hl7-v2";
+    private final static String ROUTE_PROPERTY_NAMESPACE = "lfh.connect.hl7-v2";
 
     @Override
     protected String getRoutePropertyNamespace() {
@@ -23,7 +23,7 @@ public class Hl7v2MllpRouteBuilder extends BaseRouteBuilder {
 
     @Override
     protected void buildRoute(String routePropertyNamespace) {
-        from("{{lfh.connect.hl7_v2_mllp.uri}}")
+        from("{{lfh.connect.hl7-v2.uri}}")
                 .routeId(ROUTE_ID)
                 .unmarshal().hl7()
                 .process(new MetaDataProcessor(routePropertyNamespace))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,47 +1,47 @@
 # HL7 V2 MLLP
 lfh.connect.bean.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
 lfh.connect.bean.hl7decoder=org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory
-lfh.connect.hl7_v2_mllp.host=0.0.0.0:2575
-lfh.connect.hl7_v2_mllp.uri=netty:tcp://{{lfh.connect.hl7_v2_mllp.host}}?sync=true&encoders=#hl7encoder&decoders=#hl7decoder
-lfh.connect.hl7_v2_mllp.dataformat=hl7-v2
-lfh.connect.hl7_v2_mllp.messagetype=\${header.CamelHL7MessageType}
+lfh.connect.hl7-v2.host=0.0.0.0:2575
+lfh.connect.hl7-v2.dataformat=hl7-v2
+lfh.connect.hl7-v2.uri=netty:tcp://{{lfh.connect.hl7-v2.host}}?sync=true&encoders=#hl7encoder&decoders=#hl7decoder
+lfh.connect.hl7-v2.messagetype=\${header.CamelHL7MessageType}
 
 # FHIR R4 REST
-lfh.connect.fhir_r4_rest.host=0.0.0.0
-lfh.connect.fhir_r4_rest.port=8080
-lfh.connect.fhir_r4_rest.uri=http://{{lfh.connect.fhir_r4_rest.host}}:{{lfh.connect.fhir_r4_rest.port}}/fhir/r4
-lfh.connect.fhir_r4_rest.dataformat=fhir-r4
-lfh.connect.fhir_r4_rest.messagetype=\${header.resource}
+lfh.connect.fhir-r4.host=0.0.0.0
+lfh.connect.fhir-r4.port=8080
+lfh.connect.fhir-r4.uri=http://{{lfh.connect.fhir-r4.host}}:{{lfh.connect.fhir-r4.port}}/fhir/r4
+lfh.connect.fhir-r4.dataformat=fhir-r4
+lfh.connect.fhir-r4.messagetype=\${header.resource}
 
-lfh.connect.acd_rest.auth=authMethod=Basic&authUsername=apikey&authPassword=ENC(3XsVRVv9eVphHv+CAm2sGkwKvltlrkhqBOFVXiYO89btdklYEsdu0w==)
-lfh.connect.acd_rest.version=2020-07-01
-lfh.connect.acd_rest.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow
-lfh.connect.acd_rest.host=us-east.wh-acd.cloud.ibm.com
-lfh.connect.acd_rest.baseuri=https://{{lfh.connect.acd_rest.host}}
-lfh.connect.acd_rest.uri={{lfh.connect.acd_rest.baseuri}}/wh-acd/api/v1/analyze/{{lfh.connect.acd_rest.flow}}?version={{lfh.connect.acd_rest.version}}&{{lfh.connect.acd_rest.auth}}
-lfh.connect.acd_rest.dataformat=ACD
-lfh.connect.acd_rest.messagetype=INSIGHTS
+lfh.connect.acd.auth=authMethod=Basic&authUsername=apikey&authPassword=ENC(3XsVRVv9eVphHv+CAm2sGkwKvltlrkhqBOFVXiYO89btdklYEsdu0w==)
+lfh.connect.acd.version=2020-07-01
+lfh.connect.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow
+lfh.connect.acd.host=us-east.wh-acd.cloud.ibm.com
+lfh.connect.acd.baseuri=https://{{lfh.connect.acd.host}}
+lfh.connect.acd.uri={{lfh.connect.acd.baseuri}}/wh-acd/api/v1/analyze/{{lfh.connect.acd.flow}}?version={{lfh.connect.acd.version}}&{{lfh.connect.acd.auth}}
+lfh.connect.acd.dataformat=ACD
+lfh.connect.acd.messagetype=INSIGHTS
 
 # Blue Button 2.0 REST
 # Blue Button Camel endpoint (listening endpoint/consumer)
-lfh.connect.bluebutton_20.rest.host=0.0.0.0
-lfh.connect.bluebutton_20.rest.port=8080
-lfh.connect.bluebutton_20.rest.uri=http://{{lfh.connect.bluebutton_20.rest.host}}:{{lfh.connect.bluebutton_20.rest.port}}/bluebutton/v1
+lfh.connect.bluebutton-20.host=0.0.0.0
+lfh.connect.bluebutton-20.port=8080
+lfh.connect.bluebutton-20.uri=http://{{lfh.connect.bluebutton-20.host}}:{{lfh.connect.bluebutton-20.port}}/bluebutton/v1
 
 # Blue Button OAuth2 Callbacks
-lfh.connect.bluebutton_20.callback.host=localhost
-lfh.connect.bluebutton_20.callback.port=8080
-lfh.connect.bluebutton_20.callback.baseuri={{lfh.connect.bluebutton_20.callback.host}}:{{lfh.connect.bluebutton_20.callback.port}}
-lfh.connect.bluebutton_20.authorizeuri=http://{{lfh.connect.bluebutton_20.callback.baseuri}}/bluebutton/authorize
-lfh.connect.bluebutton_20.handleruri=http://{{lfh.connect.bluebutton_20.callback.baseuri}}/bluebutton/handler
+lfh.connect.bluebutton-20.callback.host=localhost
+lfh.connect.bluebutton-20.callback.port=8080
+lfh.connect.bluebutton-20.callback.baseuri={{lfh.connect.bluebutton-20.callback.host}}:{{lfh.connect.bluebutton-20.callback.port}}
+lfh.connect.bluebutton-20.authorizeuri=http://{{lfh.connect.bluebutton-20.callback.baseuri}}/bluebutton/authorize
+lfh.connect.bluebutton-20.handleruri=http://{{lfh.connect.bluebutton-20.callback.baseuri}}/bluebutton/handler
 
 # Blue Button CMS Endpoints
-lfh.connect.bluebutton_20.cms.host=sandbox.bluebutton.cms.gov
-lfh.connect.bluebutton_20.cms.authorizeuri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/o/authorize/
-lfh.connect.bluebutton_20.cms.tokenUri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/o/token/
-lfh.connect.bluebutton_20.cms.baseuri=https://{{lfh.connect.bluebutton_20.cms.host}}/v1/fhir/
-lfh.connect.bluebutton_20.cms.clientid=ENC(MLI1vy+555l8RitLxQguke+EMnxAXTi/J15jHXcVSA4m3LapXkQ2SDjD/eXCfe729jvLAezHrHc=)
-lfh.connect.bluebutton_20.cms.clientsecret=ENC(LVddmNBkdgHTPxewJsd/ji9i36omfi9o+pBCu8aWr1HZ3CynQHR4n9lVaueats/OcupwNYiGW028/cTDP/MDU8Fe0ov2eLx8YDRPQzyimhRQSG+xPD5hqvjRCbQNsoSTC+hPe+VMdKRE+Oup6R12h3mDYOZ3BJF8heoiee2zR9obGyF+E08pmEI0BYqoKFYG)
+lfh.connect.bluebutton-20.cms.host=sandbox.bluebutton.cms.gov
+lfh.connect.bluebutton-20.cms.authorizeuri=https://{{lfh.connect.bluebutton-20.cms.host}}/v1/o/authorize/
+lfh.connect.bluebutton-20.cms.tokenuri=https://{{lfh.connect.bluebutton-20.cms.host}}/v1/o/token/
+lfh.connect.bluebutton-20.cms.baseuri=https://{{lfh.connect.bluebutton-20.cms.host}}/v1/fhir/
+lfh.connect.bluebutton-20.cms.clientid=ENC(MLI1vy+555l8RitLxQguke+EMnxAXTi/J15jHXcVSA4m3LapXkQ2SDjD/eXCfe729jvLAezHrHc=)
+lfh.connect.bluebutton-20.cms.clientsecret=ENC(LVddmNBkdgHTPxewJsd/ji9i36omfi9o+pBCu8aWr1HZ3CynQHR4n9lVaueats/OcupwNYiGW028/cTDP/MDU8Fe0ov2eLx8YDRPQzyimhRQSG+xPD5hqvjRCbQNsoSTC+hPe+VMdKRE+Oup6R12h3mDYOZ3BJF8heoiee2zR9obGyF+E08pmEI0BYqoKFYG)
 
 # Orthanc DICOM
 lfh.connect.orthanc.host=0.0.0.0

--- a/src/test/java/com/linuxforhealth/connect/builder/BlueButton20ApiTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/BlueButton20ApiTest.java
@@ -20,7 +20,7 @@ import java.util.Properties;
 import java.util.UUID;
 
 /**
- * Tests {@link BlueButton20RestRouteBuilder#API_ROUTE_ID}
+ * Tests {@link BlueButton20RouteBuilder#API_ROUTE_ID}
  */
 public class BlueButton20ApiTest extends RouteTestSupport {
 
@@ -28,7 +28,7 @@ public class BlueButton20ApiTest extends RouteTestSupport {
 
     @Override
     protected RoutesBuilder createRouteBuilder()  {
-        return new BlueButton20RestRouteBuilder();
+        return new BlueButton20RouteBuilder();
     }
 
     @Override
@@ -42,13 +42,13 @@ public class BlueButton20ApiTest extends RouteTestSupport {
     @BeforeEach
     @Override
     protected void configureContext() throws Exception {
-        setProducerResponse(BlueButton20RestRouteBuilder.API_ROUTE_ID,
-                BlueButton20RestRouteBuilder.API_ROUTE_BLUE_BUTTON_REQUEST_PRODUCER_ID,
+        setProducerResponse(BlueButton20RouteBuilder.API_ROUTE_ID,
+                BlueButton20RouteBuilder.API_ROUTE_BLUE_BUTTON_REQUEST_PRODUCER_ID,
                 "bluebutton-20",
                 "patient-result.json");
 
-        mockProducerEndpointById(BlueButton20RestRouteBuilder.API_ROUTE_ID,
-                BlueButton20RestRouteBuilder.API_ROUTE_PRODUCER_ID,
+        mockProducerEndpointById(BlueButton20RouteBuilder.API_ROUTE_ID,
+                BlueButton20RouteBuilder.API_ROUTE_PRODUCER_ID,
                 "mock:result");
 
         super.configureContext();
@@ -71,10 +71,10 @@ public class BlueButton20ApiTest extends RouteTestSupport {
         mockResult.expectedPropertyReceived("dataStoreUri", "kafka:FHIR-R4_PATIENT?brokers=localhost:9094");
         mockResult.expectedPropertyReceived("dataFormat", "FHIR-R4");
         mockResult.expectedPropertyReceived("messageType", "PATIENT");
-        mockResult.expectedPropertyReceived("routeId", "bluebutton-20-rest");
+        mockResult.expectedPropertyReceived("routeId", "bluebutton-20");
 
 
-        fluentTemplate.to("{{lfh.connect.bluebutton_20.rest.uri}}/Patient?-19990000002154")
+        fluentTemplate.to("{{lfh.connect.bluebutton-20.uri}}/Patient?-19990000002154")
                 .withHeader("Authorization", "387Rf1c2JTuduYuOQIuRHUlVOvJsib")
                 .request();
 

--- a/src/test/java/com/linuxforhealth/connect/builder/BlueButton20AuthTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/BlueButton20AuthTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Properties;
 
 /**
- * Tests {@link BlueButton20RestRouteBuilder#AUTHORIZE_ROUTE_ID}
+ * Tests {@link BlueButton20RouteBuilder#AUTHORIZE_ROUTE_ID}
  */
 public class BlueButton20AuthTest extends RouteTestSupport {
 
@@ -22,21 +22,21 @@ public class BlueButton20AuthTest extends RouteTestSupport {
 
     @Override
     protected RoutesBuilder createRouteBuilder()  {
-        return new BlueButton20RestRouteBuilder();
+        return new BlueButton20RouteBuilder();
     }
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientid", "client-id");
+        props.setProperty("lfh.connect.bluebutton-20.cms.clientid", "client-id");
         return props;
     }
 
     @BeforeEach
     @Override
     protected void configureContext() throws Exception {
-        mockProducerEndpointById(BlueButton20RestRouteBuilder.AUTHORIZE_ROUTE_ID,
-                BlueButton20RestRouteBuilder.AUTHORIZE_PRODUCER_ID,
+        mockProducerEndpointById(BlueButton20RouteBuilder.AUTHORIZE_ROUTE_ID,
+                BlueButton20RouteBuilder.AUTHORIZE_PRODUCER_ID,
                 "mock:result");
         super.configureContext();
         mockResult = MockEndpoint.resolve(context, "mock:result");
@@ -61,7 +61,7 @@ public class BlueButton20AuthTest extends RouteTestSupport {
 
         mockResult.expectedPropertyReceived("location", expectedLocation);
 
-        fluentTemplate.to("{{lfh.connect.bluebutton_20.authorizeuri}}")
+        fluentTemplate.to("{{lfh.connect.bluebutton-20.authorizeuri}}")
                 .send();
 
         mockResult.assertIsSatisfied();

--- a/src/test/java/com/linuxforhealth/connect/builder/BlueButton20CallbackTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/BlueButton20CallbackTest.java
@@ -16,7 +16,7 @@ import java.util.Base64;
 import java.util.Properties;
 
 /**
- * Tests {@link BlueButton20RestRouteBuilder#CALLBACK_ROUTE_ID}
+ * Tests {@link BlueButton20RouteBuilder#CALLBACK_ROUTE_ID}
  */
 public class BlueButton20CallbackTest extends RouteTestSupport {
 
@@ -24,23 +24,23 @@ public class BlueButton20CallbackTest extends RouteTestSupport {
 
     @Override
     protected RoutesBuilder createRouteBuilder()  {
-        return new BlueButton20RestRouteBuilder();
+        return new BlueButton20RouteBuilder();
     }
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         Properties props = super.useOverridePropertiesWithPropertiesComponent();
-        props.setProperty("lfh.connect.bluebutton_20.cms.tokenUri", "https://sandbox.bluebutton.cms.gov/v1/o/token/");
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientid", "client-id");
-        props.setProperty("lfh.connect.bluebutton_20.cms.clientsecret", "client-secret");
+        props.setProperty("lfh.connect.bluebutton-20.cms.tokenUri", "https://sandbox.bluebutton.cms.gov/v1/o/token/");
+        props.setProperty("lfh.connect.bluebutton-20.cms.clientid", "client-id");
+        props.setProperty("lfh.connect.bluebutton-20.cms.clientsecret", "client-secret");
         return props;
     }
 
     @BeforeEach
     @Override
     protected void configureContext() throws Exception {
-        mockProducerEndpointById(BlueButton20RestRouteBuilder.CALLBACK_ROUTE_ID,
-                BlueButton20RestRouteBuilder.CALLBACK_PRODUCER_ID,
+        mockProducerEndpointById(BlueButton20RouteBuilder.CALLBACK_ROUTE_ID,
+                BlueButton20RouteBuilder.CALLBACK_PRODUCER_ID,
                 "mock:result");
         super.configureContext();
         mockResult = MockEndpoint.resolve(context, "mock:result");
@@ -66,7 +66,7 @@ public class BlueButton20CallbackTest extends RouteTestSupport {
         mockResult.expectedHeaderReceived("Content-Type", "application/x-www-form-urlencoded");
         mockResult.expectedHeaderReceived("Content-Length", expectedBody.length());
 
-        fluentTemplate.to("{{lfh.connect.bluebutton_20.handleruri}}")
+        fluentTemplate.to("{{lfh.connect.bluebutton-20.handleruri}}")
                 .withHeader("code", "auth-code")
                 .send();
 

--- a/src/test/java/com/linuxforhealth/connect/builder/FhirR4RouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/FhirR4RouteTest.java
@@ -19,15 +19,15 @@ import java.util.Base64;
 import java.util.UUID;
 
 /**
- * Tests {@link FhirR4RestRouteBuilder}
+ * Tests {@link FhirR4RouteBuilder}
  */
-public class FhirR4RestRouteTest extends RouteTestSupport {
+public class FhirR4RouteTest extends RouteTestSupport {
 
     private MockEndpoint mockResult;
 
     @Override
     protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new FhirR4RestRouteBuilder();
+        return new FhirR4RouteBuilder();
     }
 
     /**
@@ -38,8 +38,8 @@ public class FhirR4RestRouteTest extends RouteTestSupport {
     @Override
     protected void configureContext() throws Exception {
         mockProducerEndpointById(
-                FhirR4RestRouteBuilder.ROUTE_ID,
-                FhirR4RestRouteBuilder.ROUTE_PRODUCER_ID,
+                FhirR4RouteBuilder.ROUTE_ID,
+                FhirR4RouteBuilder.ROUTE_PRODUCER_ID,
                 "mock:result"
         );
 
@@ -62,9 +62,9 @@ public class FhirR4RestRouteTest extends RouteTestSupport {
         mockResult.expectedPropertyReceived("dataStoreUri", "kafka:FHIR-R4_PATIENT?brokers=localhost:9094");
         mockResult.expectedPropertyReceived("dataFormat", "FHIR-R4");
         mockResult.expectedPropertyReceived("messageType", "PATIENT");
-        mockResult.expectedPropertyReceived("routeId", "fhir-r4-rest");
+        mockResult.expectedPropertyReceived("routeId", "fhir-r4");
 
-        fluentTemplate.to("{{lfh.connect.fhir_r4_rest.uri}}/Patient")
+        fluentTemplate.to("{{lfh.connect.fhir-r4.uri}}/Patient")
                 .withBody(testMessage)
                 .send();
 

--- a/src/test/java/com/linuxforhealth/connect/builder/Hl7v2RouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/Hl7v2RouteTest.java
@@ -21,15 +21,15 @@ import java.util.Base64;
 import java.util.UUID;
 
 /**
- * Tests {@link Hl7v2MllpRouteBuilder}
+ * Tests {@link Hl7v2RouteBuilder}
  */
-public class Hl7v2MllpRouteTest extends RouteTestSupport {
+public class Hl7v2RouteTest extends RouteTestSupport {
 
     private MockEndpoint mockResult;
 
     @Override
     protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new Hl7v2MllpRouteBuilder();
+        return new Hl7v2RouteBuilder();
     }
 
     /**
@@ -46,8 +46,8 @@ public class Hl7v2MllpRouteTest extends RouteTestSupport {
         context.getRegistry().bind("hl7decoder", hl7decoder);
 
         mockProducerEndpointById(
-                Hl7v2MllpRouteBuilder.ROUTE_ID,
-                Hl7v2MllpRouteBuilder.ROUTE_PRODUCER_ID,
+                Hl7v2RouteBuilder.ROUTE_ID,
+                Hl7v2RouteBuilder.ROUTE_PRODUCER_ID,
                 "mock:result"
         );
 
@@ -73,9 +73,9 @@ public class Hl7v2MllpRouteTest extends RouteTestSupport {
         mockResult.expectedPropertyReceived("dataStoreUri", "kafka:HL7-V2_ADT?brokers=localhost:9094");
         mockResult.expectedPropertyReceived("dataFormat", "HL7-V2");
         mockResult.expectedPropertyReceived("messageType", "ADT");
-        mockResult.expectedPropertyReceived("routeId", "hl7-v2-mllp");
+        mockResult.expectedPropertyReceived("routeId", "hl7-v2");
 
-        fluentTemplate.to("{{lfh.connect.hl7_v2_mllp.uri}}")
+        fluentTemplate.to("{{lfh.connect.hl7-v2.uri}}")
                 .withBody(testMessage)
                 .send();
 

--- a/src/test/java/com/linuxforhealth/connect/builder/OrthancRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/OrthancRouteTest.java
@@ -18,7 +18,7 @@ import java.util.Properties;
 import java.util.UUID;
 
 /**
- * Tests {@link FhirR4RestRouteBuilder}
+ * Tests {@link FhirR4RouteBuilder}
  */
 public class OrthancRouteTest extends RouteTestSupport {
 


### PR DESCRIPTION
PR https://github.com/LinuxForHealth/connect/pull/131 updated LFH to support translating environment variable application settings to application.property settings. This translation assumes that application property setting names are in lowercase and do not use an underscore. 

This PR updates existing application.properties and the supporting code to support this "standard"