### PR TITLE
Clarifying docker compose stack verbiage

### DIFF
--- a/container-support/compose/README.md
+++ b/container-support/compose/README.md
@@ -1,18 +1,22 @@
-# Linux for Health Docker Compose Stacks
+# Linux for Health Docker Compose
 
-Docker Compose supports various application stacks through the use Docker Compose's [COMPOSE_FILE](https://docs.docker.com/compose/reference/envvars/#compose_file) environment variable.
-The `start-stack.sh` script launches Linux for Health Docker Compose stacks.
+LFH supports multiple "profiles" stacks through the use of Docker Compose's [COMPOSE_FILE](https://docs.docker.com/compose/reference/envvars/#compose_file) environment variable.
+The `start-stack.sh` script launches the Linux for Health Docker Compose stack for the specified profile.
 
 start-stack.sh usage
 ```shell script
 # it is recommend to execute the script within the current shell to ensure that the docker-compose CLI behaves
 # as expected following service startup
-. ./start-stack.sh [stack name]
+. ./start-stack.sh [profile name]
+# OR
+source start-stack.sh [profile name]
 ```
 
-## Supported Stacks
-| Stack Name | Stack Description |
+## Supported Profiles
+| Profile Name | Profile Description |
 | :--- | :--- |
 | dev | For local development use. Runs LFH supporting services with port mappings. |
 | server | For deployment environments or integrated testing. Includes the LFH connect application and supporting services. |
 | pi | Similar to the server stack. Optimized for arm64/Raspberry Pi usage. |
+
+## S

--- a/container-support/compose/start-stack.sh
+++ b/container-support/compose/start-stack.sh
@@ -1,43 +1,50 @@
 #!/bin/sh
 # start-stack.sh
-# Starts a LFH Docker Compose Stack
-# Usage: ./start-stack.sh [compose stack] where compose stack is one of dev, server or pi.
-# [compose stack] "defaults" to dev
+# Starts the LFH Docker Compose Stack for a specified profile. The profile determines which configurations are included
+# in the startup process.
+#
+# Usage: ./start-stack.sh [profile name] where profile is one of dev, server or pi.
+# [profile name] "defaults" to dev
 #
 # It is recommended to run this script in the current shell session, so that the docker-compose
 # CLI will evaluate it's commands using the COMPOSE_FILE variable set in this script.
 # Example:
 # . ./start-stack.sh server
+# OR
+# source start-stack.sh server
 set -o errexit
 set -o nounset
 set -o pipefail
 
-LFH_COMPOSE_STACK=${1:-dev}
+LFH_COMPOSE_PROFILE=${1:-dev}
+echo "${LFH_COMPOSE_PROFILE}"
 
 echo "==============================================="
 echo "LFH Compose Startup"
-echo "LFH compose stack is set to ${LFH_COMPOSE_STACK}"
+echo "LFH compose profile is set to ${LFH_COMPOSE_PROFILE}"
 
-case "${LFH_COMPOSE_STACK}" in
+case "${LFH_COMPOSE_PROFILE}" in
   dev)
-  echo "starting LFH compose development stack"
+  echo "starting LFH compose development profile"
   export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
   ;;
   server)
-  echo "starting LFH compose server stack"
+  echo "starting LFH compose server profile"
   export COMPOSE_FILE=docker-compose.yml:docker-compose.server.yml
   ;;
   pi)
-  echo "starting LFH compose pi stack"
+  echo "starting LFH compose pi profile"
   export COMPOSE_FILE=docker-compose.yml:docker-compose.server.yml:docker-compose.pi.yml
   ;;
   *)
-  echo "invalid LFH Compose Stack. Expecting one of:dev, server, pi"
+  echo "invalid LFH Compose Profile. Expecting one of:dev, server, pi"
+  export COMPOSE_FILE=""
   ;;
 esac
 
 if [ -n "${COMPOSE_FILE}" ]; then
-  echo "Parsing compose files for ${LFH_COMPOSE_STACK} stack. COMPOSE_FILE=${COMPOSE_FILE}"
+  echo "Parsing compose files for ${LFH_COMPOSE_PROFILE} profile."
+  echo "COMPOSE_FILE=${COMPOSE_FILE}"
   docker-compose up -d
   docker-compose ps
 fi


### PR DESCRIPTION
This PR updates the docker compose "start stack" script by clarifying some verbiage concerning stacks and profiles. The previous implementation was a bit confusing as "stack" is a term used in docker swarm. In regards to the "start stack" script, the script starts a "stack" given a specified profile of dev, server, or pi.