### PR TITLE
Map NATS Subscriber Client Port to HOST OS

### DIFF
--- a/container-support/compose/docker-compose.server.yml
+++ b/container-support/compose/docker-compose.server.yml
@@ -1,5 +1,8 @@
 version: "3.7"
 services:
+  nats-server:
+    ports:
+      - ${LFH_NATS_CLIENT_PORT}:${LFH_NATS_CLIENT_PORT}
   lfh:
     image: ${LFH_CONNECT_IMAGE}
     restart: "always"

--- a/container-support/oci/start.sh
+++ b/container-support/oci/start.sh
@@ -58,7 +58,9 @@ echo "launch nats container"
 ${OCI_COMMAND} run -d \
               --network "${LFH_NETWORK_NAME}" \
               --name "${LFH_NATS_SERVICE_NAME}" \
+              -p "${LFH_NATS_CLIENT_PORT}":"${LFH_NATS_CLIENT_PORT}" \
               "${LFH_NATS_IMAGE}"
+is_ready localhost "${LFH_NATS_CLIENT_PORT}"
 
 echo "launch zookeeper container"
 ${OCI_COMMAND} pull "${LFH_ZOOKEEPER_IMAGE}"

--- a/container-support/openshift/install-quickstart.sh
+++ b/container-support/openshift/install-quickstart.sh
@@ -32,6 +32,12 @@ oc new-app "${LFH_NATS_IMAGE}" \
 
 oc rollout status deployment/"${LFH_NATS_SERVICE_NAME}" -w
 
+oc expose service "${LFH_NATS_SERVICE_NAME}" \
+  --labels='app='"${LFH_NATS_SERVICE_NAME}" \
+  --port="${LFH_NATS_CLIENT_PORT}" \
+  --hostname="lfh-nats-server.apps-crc.testing" \
+  --name="lfh-nats-server"
+
 # Zookeeper - Kafka Metadata
 oc new-app "${LFH_ZOOKEEPER_IMAGE}" \
     --name="${LFH_ZOOKEEPER_SERVICE_NAME}" \


### PR DESCRIPTION
This PR maps the NATS Server's  Client Port, 4222, to the HOST OS. This port mapping supports incoming connections from other NATS Subscribers running on other Linux For Health Nodes.

I tested the updates by using curl/telnet to verify that the port is open and available.

```
dixons-mbp oci$ curl telnet://localhost:4222
INFO {"server_id":"NAIH7VT2HCNDN5XL5JMFJ7WHCMPYMK6UVZDJR2L55QEXFD53UHB3DMT7",
"server_name":"NAIH7VT2HCNDN5XL5JMFJ7WHCMPYMK6UVZDJR2L55QEXFD53UHB3DMT7",
"version":"2.1.7",
"proto":1,
"git_commit":"bf0930ee",
"go":"go1.13.4","host":"0.0.0.0",
"port":4222,
"max_payload":1048576,
"client_id":5,"
client_ip":"172.27.0.1"
}
``` 