### PR TITLE
Copy exchange obj rather than create new one

### DIFF
--- a/src/main/java/com/linuxforhealth/connect/processor/FhirR4ToAcdProcessor.java
+++ b/src/main/java/com/linuxforhealth/connect/processor/FhirR4ToAcdProcessor.java
@@ -67,12 +67,13 @@ public class FhirR4ToAcdProcessor implements Processor {
 		
 		for (DocumentReferenceContentComponent content:docRef.getContent()) {
 			
-			Exchange docEx = new DefaultExchange(exchange.getContext());
-			docEx.getIn().setBody(content.getAttachment().getData(), String.class);
-			docEx.getIn().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+			Exchange contentExchange = exchange.copy();
+			
+			contentExchange.getIn().setBody(content.getAttachment().getData(), String.class);
+			contentExchange.getIn().setHeader(Exchange.CONTENT_TYPE, "text/plain");
 			
 			ProducerTemplate pt = exchange.getContext().createProducerTemplate();
-			pt.send("direct:acd-analyze", docEx);
+			pt.send("direct:acd-analyze", contentExchange);
 		}
 		
 	}


### PR DESCRIPTION
Creating a new `DefaultExchange` object resulted in a MetaDataProcessor.process(...) error whereby `exchange.getFromEndpoint()` returns null.
The `exchange.copy()` method retains the original "from" endpoint where the exchange originated and that's useful information.

We may want to add some error handling / logging within MetaDataProcessor to make it easier to identify problematic property settings. The only error I saw in the logs for the issue I described above was:
```
11:14:04.637 [Camel (camel-1) thread #1 - KafkaConsumer[FHIR-R4_DOCUMENTREFERENCE]] ERROR c.l.c.b.LinuxForHealthRouteBuilder - simple{}
```