### PR TITLE
Update Shell Scripts to Explicitly Use Bash

### DIFF
--- a/container-support/compose/start-stack.sh
+++ b/container-support/compose/start-stack.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # start-stack.sh
 # Starts the LFH Docker Compose Stack for a specified profile. The profile determines which configurations are included
 # in the startup process.

--- a/container-support/oci/lfh-oci-services.sh
+++ b/container-support/oci/lfh-oci-services.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # lfh-oci-services.sh
 #
 # Usage:

--- a/container-support/openshift/aro-quickstart.sh
+++ b/container-support/openshift/aro-quickstart.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # aro-quickstart.sh
 # Install or removes Azure Redhat OpenShift resources (OCP) within an existing Azure Subscription.
 #

--- a/container-support/openshift/lfh-quickstart.sh
+++ b/container-support/openshift/lfh-quickstart.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # lfh-quickstart.sh
 # Provisions the LFH quick start stack into an existing OpenShift 4.x cluster.
 #

--- a/utils/cp-docker.sh
+++ b/utils/cp-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 docker cp create-topics.sh idaas-connect_kafka_1:/opt/kafka_2.12-2.3.0/bin
 docker cp hl7-msgs.txt idaas-connect_kafka_1:/opt/kafka_2.12-2.3.0/bin

--- a/utils/create-topics.sh
+++ b/utils/create-topics.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 while read p; do
   topic=HL7v2_$p


### PR DESCRIPTION
Our shell scripts are using a "preamble" of `#!/bin/sh`, but are also using "bash specific" options such as
```
set -o errexit
set -o nounset
set -o pipefail
```

This results in errors such as the following on Ubuntu
```
set: Illegal option -o pipefail
```

Suggested resolution: Update shell scripts to explicitly use bash.
