### PR TITLE
ARO Removal/Deletion Fix

### DIFF
--- a/container-support/openshift/README.md
+++ b/container-support/openshift/README.md
@@ -39,8 +39,9 @@ When provisioning is complete, view connection information
 
 To remove/delete the OCP quickstart
 ```shell script
-# the script will return once the deletion requests are sent to the Azure Resource Manager
 ./aro-quickstart [Subscription Name] [Resource Group Name] [Region Name] remove
+# the script will return once the deletion requests are sent to the Azure Resource Manager, and provide commands
+# to monitor deletion progress and remove remaining resources.
 ```
 
 ## Provision LFH Within an Existing OCP Cluster

--- a/container-support/openshift/aro-quickstart.sh
+++ b/container-support/openshift/aro-quickstart.sh
@@ -185,8 +185,17 @@ function remove() {
   echo "${DISPLAY_BREAK}"
 
   az aro delete --yes --resource-group "${RESOURCE_GROUP_NAME}" --name "${ARO_CLUSTER_NAME}" --no-wait
-  az ad sp delete --id "${SERVICE_PRINCIPAL_NAME}"
-  az group delete --yes --name "${RESOURCE_GROUP_NAME}"
+  echo "The request to delete the ARO Cluster has been submitted. Please monitor progress using the Azure Portal or Azure CLI."
+  echo "Azure CLI monitoring command:"
+  echo "az aro show --name ${ARO_CLUSTER_NAME} --resource-group ${RESOURCE_GROUP_NAME} --query \"[provisioningState]\" --output tsv"
+  echo "${DISPLAY_BREAK}"
+  echo "The command will return the following error, once the cluster is deleted:"
+  echo "     The Resource Microsoft.RedHatOpenShift/OpenShiftClusters/lfh-aro-cluster under resource group ${RESOURCE_GROUP_NAME} was not found"
+  echo "${DISPLAY_BREAK}"
+  echo "Once the cluster id deleted, use the following commands to remove the remaining ARO resources:"
+  echo "az ad sp delete --id ${SERVICE_PRINCIPAL_NAME}"
+  echo "az group delete --yes --name ${RESOURCE_GROUP_NAME}"
+  echo "${DISPLAY_BREAK}"
 }
 
 function connection_info() {


### PR DESCRIPTION
This PR updates the aro-quickstart.sh remove operation to submit the command to remove the ARO cluster, and then provide the user/cli with the subsequent commands to run once the cluster is deleted.