### PR TITLE
Update OCI and OpenShift Runtimes to NATS Subscriber and Kafka Broker Configs

### DIFF
--- a/container-support/oci/lfh-oci-services.sh
+++ b/container-support/oci/lfh-oci-services.sh
@@ -113,6 +113,8 @@ function start() {
                 --env LFH_CONNECT_MESSAGING_URI="nats:lfh-events?servers=nats-server:4222" \
                 --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
                 --env LFH_CONNECT_ORTHANC_SERVER_URI="http://orthanc:{{lfh.connect.orthanc_server.port}}/instances" \
+                --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
+                --env LFH_CONNECT_DATASTORE_BROKERS="kafka:9092" \
                 "${LFH_CONNECT_IMAGE}"
 
   is_ready localhost "${LFH_CONNECT_MLLP_PORT}"

--- a/container-support/openshift/lfh-quickstart.sh
+++ b/container-support/openshift/lfh-quickstart.sh
@@ -43,8 +43,8 @@ function install() {
   oc expose service "${LFH_NATS_SERVICE_NAME}" \
     --labels='app='"${LFH_NATS_SERVICE_NAME}" \
     --port="${LFH_NATS_CLIENT_PORT}" \
-    --hostname="lfh-nats-server.apps-crc.testing" \
-    --name="lfh-nats-server"
+    --name="lfh-nats-server" \
+    --generator='route/v1'
 
   # Zookeeper - Kafka Metadata
   oc new-app "${LFH_ZOOKEEPER_IMAGE}" \
@@ -92,6 +92,8 @@ function install() {
     --env LFH_CONNECT_MESSAGING_URI="nats:lfh-events?servers=nats-server:4222" \
     --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
     --env LFH_CONNECT_ORTHANC_SERVER_URI="http://orthanc:{{lfh.connect.orthanc_server.port}}/instances" \
+    --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
+    --env LFH_CONNECT_DATASTORE_BROKERS="kafka:9092" \
     --show-all=true
 
   oc rollout status deployment/"${LFH_CONNECT_SERVICE_NAME}" -w


### PR DESCRIPTION
This PR updates the OCI and OpenShift scripts to support the following configs/env variables:

- LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS
- LFH_CONNECT_DATASTORE_BROKERS