### PR TITLE
Add kubernetes deployment/services yaml

### DIFF
--- a/container-support/kubernetes/README.md
+++ b/container-support/kubernetes/README.md
@@ -1,0 +1,11 @@
+# Linux for Health Kubernetes
+
+LFH can be deployed to a kubernetes cluster using lfh-all.yaml. 
+
+From the "connect" project folder, run: 
+``kubectl apply -f container-support/kubernetes/lfh-all.yaml``
+
+The following ports are configured by default on the target cluster:
+* 30000: Kafdrop
+* 31000: LFH Http port
+* 32000: HL7 port

--- a/container-support/kubernetes/lfh-all.yaml
+++ b/container-support/kubernetes/lfh-all.yaml
@@ -86,6 +86,6 @@ spec:
             - containerPort: 8042
               protocol: TCP
         - name: lfh
-          image: 'docker.io/atclark/lfh:latest'
+          image: 'docker.io/linuxforhealth/connect:1.0.0'
           ports:
             - containerPort: 8081

--- a/container-support/kubernetes/lfh-all.yaml
+++ b/container-support/kubernetes/lfh-all.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lfh-all
+  labels:
+    app: lfh-all
+spec:
+  ports:
+    - port: 9000
+      name: kafdrop-port
+      protocol: TCP
+      nodePort: 30000
+    - name: lfh-port
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+      nodePort: 31000
+    - name: lfh-hl7-port
+      protocol: TCP
+      port: 2575
+      targetPort: 2575
+      nodePort: 32000
+  selector:
+    app: lfh-all
+  type: NodePort
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: lfh-all
+spec:
+  selector:
+    matchLabels:
+      app: lfh-all
+  template:
+    metadata:
+      labels:
+        app: lfh-all
+    spec:
+      containers:
+        - name: zoo1
+          image: docker.io/zookeeper
+          ports:
+            - containerPort: 2181
+          env:
+            - name: ZOOKEEPER_ID
+              value: "1"
+            - name: ZOOKEEPER_SERVER_1
+              value: zoo1
+        - name: kafka
+          image: docker.io/wurstmeister/kafka
+          ports:
+            - containerPort: 9092
+          env:
+            - name: KAFKA_ADVERTISED_PORT
+              value: '9092'
+            - name: KAFKA_ADVERTISED_HOST_NAME
+              value: 'localhost'
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: localhost:2181
+            - name: KAFKA_BROKER_ID
+              value: "0"
+            - name: KAFKA_CREATE_TOPICS
+              value: sample.topic:1:1
+        - name: kafdrop
+          image: docker.io/obsidiandynamics/kafdrop
+          ports:
+            - containerPort: 9000
+          env:
+            - name: KAFKA_BROKERCONNECT
+              value: 'localhost:9092'
+            - name: JVM_OPTS
+              value: "-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
+        - name: nats
+          image: 'docker.io/nats:2.1.7'
+          ports:
+            - containerPort: 4222
+              protocol: TCP
+            - containerPort: 8222
+              protocol: TCP
+            - containerPort: 6222
+              protocol: TCP
+        - name: orthanc
+          image: 'docker.io/linuxforhealth/orthanc:1.7.2'
+          ports:
+            - containerPort: 8042
+              protocol: TCP
+        - name: lfh
+          image: 'docker.io/atclark/lfh:latest'
+          ports:
+            - containerPort: 8081

--- a/container-support/kubernetes/lfh-all.yaml
+++ b/container-support/kubernetes/lfh-all.yaml
@@ -89,3 +89,12 @@ spec:
           image: 'docker.io/linuxforhealth/connect:1.0.0'
           ports:
             - containerPort: 8081
+          env:
+            - name: lfh_connect_fhir-r4_port
+              value: '8081'
+            - name: lfh_connect_bluebutton-20_port
+              value: '8081'
+            - name: lfh_connect_bluebutton-20_callback_port
+              value: '8081'
+            - name: lfh_connect_datastore_brokers
+              value: 'localhost:9092'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,10 +28,6 @@ lfh.connect.acd.uri={{lfh.connect.acd.baseuri}}/wh-acd/api/v1/analyze/{{lfh.conn
 lfh.connect.acd.dataformat=ACD
 lfh.connect.acd.messagetype=INSIGHTS
 
-#LfH to HRI routes
-lfh.connect.lfhtohri.fhir.uri={{lfh.connect.datastore.host}}:FHIR-R4_PATIENT?brokers=localhost:9092
-lfh.connect.lfhtohri.hl7.uri={{lfh.connect.datastore.host}}:HL7-V2_ADT?brokers=localhost:9092
-
 # Blue Button 2.0 REST
 # Blue Button Camel endpoint (listening endpoint/consumer)
 lfh.connect.bluebutton-20.host=0.0.0.0
@@ -63,7 +59,7 @@ lfh.connect.orthanc_server.host=localhost
 lfh.connect.orthanc_server.port=8042
 lfh.connect.orthanc_server.uri=http://{{lfh.connect.orthanc_server.host}}:{{lfh.connect.orthanc_server.port}}/instances
 lfh.connect.orthanc_server.external.uri=http://{{lfh.connect.external.host.ip}}:{{lfh.connect.orthanc_server.port}}/instances
-lfh.connect.orthanc.image.uri=jetty:http://{{lfh.connect.orthanc.host}}:{{lfh.connect.orthanc.port}}/orthanc/images?httpMethodRestrict=GET
+lfh.connect.orthanc.image.uri=jetty:http://{{lfh.connect.orthanc.host}}:{{lfh.connect.orthanc.port}}/orthanc/images?httpMethodRestrict=GET    
 
 # Example route
 lfh.connect.example.uri=jetty:http://{{lfh.connect.host}}:{{lfh.connect.http.port}}/hello-world?httpMethodRestrict=GET

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ lfh.connect.hl7-v2.messagetype=\${header.CamelHL7MessageType}
 
 # FHIR R4 REST
 lfh.connect.fhir-r4.host=0.0.0.0
-lfh.connect.fhir-r4.port=8080
+lfh.connect.fhir-r4.port=8081
 lfh.connect.fhir-r4.uri=http://{{lfh.connect.fhir-r4.host}}:{{lfh.connect.fhir-r4.port}}/fhir/r4
 lfh.connect.fhir-r4.dataformat=fhir-r4
 lfh.connect.fhir-r4.messagetype=\${header.resource}
@@ -31,12 +31,12 @@ lfh.connect.acd.messagetype=INSIGHTS
 # Blue Button 2.0 REST
 # Blue Button Camel endpoint (listening endpoint/consumer)
 lfh.connect.bluebutton-20.host=0.0.0.0
-lfh.connect.bluebutton-20.port=8080
+lfh.connect.bluebutton-20.port=8081
 lfh.connect.bluebutton-20.uri=http://{{lfh.connect.bluebutton-20.host}}:{{lfh.connect.bluebutton-20.port}}/bluebutton/v1
 
 # Blue Button OAuth2 Callbacks
 lfh.connect.bluebutton-20.callback.host=localhost
-lfh.connect.bluebutton-20.callback.port=8080
+lfh.connect.bluebutton-20.callback.port=8081
 lfh.connect.bluebutton-20.callback.baseuri={{lfh.connect.bluebutton-20.callback.host}}:{{lfh.connect.bluebutton-20.callback.port}}
 lfh.connect.bluebutton-20.authorizeuri=http://{{lfh.connect.bluebutton-20.callback.baseuri}}/bluebutton/authorize
 lfh.connect.bluebutton-20.handleruri=http://{{lfh.connect.bluebutton-20.callback.baseuri}}/bluebutton/handler

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ lfh.connect.hl7-v2.messagetype=\${header.CamelHL7MessageType}
 
 # FHIR R4 REST
 lfh.connect.fhir-r4.host=0.0.0.0
-lfh.connect.fhir-r4.port=8081
+lfh.connect.fhir-r4.port=8080
 lfh.connect.fhir-r4.uri=http://{{lfh.connect.fhir-r4.host}}:{{lfh.connect.fhir-r4.port}}/fhir/r4
 lfh.connect.fhir-r4.dataformat=fhir-r4
 lfh.connect.fhir-r4.messagetype=\${header.resource}
@@ -28,15 +28,19 @@ lfh.connect.acd.uri={{lfh.connect.acd.baseuri}}/wh-acd/api/v1/analyze/{{lfh.conn
 lfh.connect.acd.dataformat=ACD
 lfh.connect.acd.messagetype=INSIGHTS
 
+#LfH to HRI routes
+lfh.connect.lfhtohri.fhir.uri={{lfh.connect.datastore.host}}:FHIR-R4_PATIENT?brokers=localhost:9092
+lfh.connect.lfhtohri.hl7.uri={{lfh.connect.datastore.host}}:HL7-V2_ADT?brokers=localhost:9092
+
 # Blue Button 2.0 REST
 # Blue Button Camel endpoint (listening endpoint/consumer)
 lfh.connect.bluebutton-20.host=0.0.0.0
-lfh.connect.bluebutton-20.port=8081
+lfh.connect.bluebutton-20.port=8080
 lfh.connect.bluebutton-20.uri=http://{{lfh.connect.bluebutton-20.host}}:{{lfh.connect.bluebutton-20.port}}/bluebutton/v1
 
 # Blue Button OAuth2 Callbacks
 lfh.connect.bluebutton-20.callback.host=localhost
-lfh.connect.bluebutton-20.callback.port=8081
+lfh.connect.bluebutton-20.callback.port=8080
 lfh.connect.bluebutton-20.callback.baseuri={{lfh.connect.bluebutton-20.callback.host}}:{{lfh.connect.bluebutton-20.callback.port}}
 lfh.connect.bluebutton-20.authorizeuri=http://{{lfh.connect.bluebutton-20.callback.baseuri}}/bluebutton/authorize
 lfh.connect.bluebutton-20.handleruri=http://{{lfh.connect.bluebutton-20.callback.baseuri}}/bluebutton/handler
@@ -59,7 +63,7 @@ lfh.connect.orthanc_server.host=localhost
 lfh.connect.orthanc_server.port=8042
 lfh.connect.orthanc_server.uri=http://{{lfh.connect.orthanc_server.host}}:{{lfh.connect.orthanc_server.port}}/instances
 lfh.connect.orthanc_server.external.uri=http://{{lfh.connect.external.host.ip}}:{{lfh.connect.orthanc_server.port}}/instances
-lfh.connect.orthanc.image.uri=jetty:http://{{lfh.connect.orthanc.host}}:{{lfh.connect.orthanc.port}}/orthanc/images?httpMethodRestrict=GET    
+lfh.connect.orthanc.image.uri=jetty:http://{{lfh.connect.orthanc.host}}:{{lfh.connect.orthanc.port}}/orthanc/images?httpMethodRestrict=GET
 
 # Example route
 lfh.connect.example.uri=jetty:http://{{lfh.connect.host}}:{{lfh.connect.http.port}}/hello-world?httpMethodRestrict=GET


### PR DESCRIPTION
This will provide a kubernetes yaml that can be used to deploy LfH to kubernetes and expose the necessary ports.  The one change to existing code was to update default http port from 8080 to 8081 for LfH due to a duplicate port between LfH and another service.