### PR TITLE
Migrate OCI_COMAND from Env Setting to Script Parameter

### DIFF
--- a/container-support/oci/.env
+++ b/container-support/oci/.env
@@ -9,5 +9,3 @@ LFH_NETWORK_NAME=lfh-network
 # Kafdrop JVM variable requires double-quoting and cannot is not stored in the compose ".env" file
 # until https://github.com/docker/compose/issues/2854 is merged into a Docker Desktop release
 LFH_KAFDROP_JVM_OPTS="-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
-
-OCI_COMMAND="sudo podman"

--- a/container-support/oci/lfh-oci-services.sh
+++ b/container-support/oci/lfh-oci-services.sh
@@ -2,8 +2,9 @@
 # lfh-oci-services.sh
 #
 # Usage:
-# ./lfh-oci-services.sh [start | remove]
-
+# ./lfh-oci-services.sh [start | remove] [oci_command]
+#
+# The oci_command defaults to "docker"
 
 set -o errexit
 set -o nounset
@@ -14,6 +15,8 @@ source ../compose/.env
 source .env
 
 SERVICE_OPERATION=$1
+# the container command used - docker, podman, etc
+OCI_COMMAND=${2:-"docker"}
 
 function is_ready {
   # returns 0 if the service is "ready" or 1 if the service is not ready after "${LFH_RETRY_ATTEMPTS}" are exhausted


### PR DESCRIPTION
This PR refactors the `OCI_COMMAND` environment variable defined in container-support/oci/.env to be an optional script parameter for lfh-oci-services.sh. This makes the script a bit easier to use since the command may be passed as an argument. The OCI_COMMAND parameter defaults to "docker"

```
# OCI_COMMAND defaults to docker
./lfh-oci-services.sh start

#OCI_COMMAND is set to sudo podman for "rooted" podman
./lfh-oci-services.sh start "sudo podman"
```