### PR TITLE
Remove Duplicate LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS Variables

### DIFF
--- a/container-support/oci/lfh-oci-services.sh
+++ b/container-support/oci/lfh-oci-services.sh
@@ -116,7 +116,6 @@ function start() {
                 --env LFH_CONNECT_MESSAGING_URI="nats:lfh-events?servers=nats-server:4222" \
                 --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
                 --env LFH_CONNECT_ORTHANC_SERVER_URI="http://orthanc:{{lfh.connect.orthanc_server.port}}/instances" \
-                --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
                 --env LFH_CONNECT_DATASTORE_BROKERS="kafka:9092" \
                 "${LFH_CONNECT_IMAGE}"
 

--- a/container-support/openshift/lfh-quickstart.sh
+++ b/container-support/openshift/lfh-quickstart.sh
@@ -92,7 +92,6 @@ function install() {
     --env LFH_CONNECT_MESSAGING_URI="nats:lfh-events?servers=nats-server:4222" \
     --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
     --env LFH_CONNECT_ORTHANC_SERVER_URI="http://orthanc:{{lfh.connect.orthanc_server.port}}/instances" \
-    --env LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS="nats-server:4222" \
     --env LFH_CONNECT_DATASTORE_BROKERS="kafka:9092" \
     --show-all=true
 


### PR DESCRIPTION
This PR removes duplicate LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS variables from the OCI and OpenShift management scripts.