### PR TITLE
Add NodePort Service Config For NATS Client Connectivity

### DIFF
--- a/container-support/openshift/lfh-quickstart.sh
+++ b/container-support/openshift/lfh-quickstart.sh
@@ -46,6 +46,8 @@ function install() {
     --name="lfh-nats-server" \
     --generator='route/v1'
 
+  oc apply -f nats-server-ingress.yml --wait=true
+
   # Zookeeper - Kafka Metadata
   oc new-app "${LFH_ZOOKEEPER_IMAGE}" \
       --name="${LFH_ZOOKEEPER_SERVICE_NAME}" \

--- a/container-support/openshift/nats-server-ingress.yml
+++ b/container-support/openshift/nats-server-ingress.yml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nats-server-ingress
+spec:
+  selector:
+    app: nats-server
+  ports:
+    - protocol: TCP
+      port: 4222
+      nodePort: 32321
+  type: NodePort


### PR DESCRIPTION
This PR exposes the NATS Server client port using a Kubernetes NodePort - https://kubernetes.io/docs/concepts/services-networking/service/#nodeport.

NodePorts work within a defined port range of 30000-32767. We are using a yaml service configuration so that we can specify a specific port.

I tested locally on CRC and verified that I can access the NATS Server client port via IP
```
Dixons-MBP openshift$ oc get services
NAME                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                               AGE
kafdrop               ClusterIP   172.25.104.230   <none>        9000/TCP                              17s
kafka                 ClusterIP   172.25.93.134    <none>        9092/TCP,9094/TCP                     22s
lfh                   ClusterIP   172.25.216.46    <none>        2575/TCP,8080/TCP,9090/TCP            12s
nats-server           ClusterIP   172.25.95.81     <none>        4222/TCP,5222/TCP,6222/TCP,8222/TCP   34s
nats-server-ingress   NodePort    172.25.62.93     <none>        4222:32321/TCP                        28s
orthanc               ClusterIP   172.25.159.171   <none>        4242/TCP,8042/TCP                     34s
zookeeper             ClusterIP   172.25.138.159   <none>        2181/TCP                              27s
Dixons-MBP openshift$ curl -v telnet://192.168.64.2:32321
*   Trying 192.168.64.2...
* TCP_NODELAY set
* Connected to 192.168.64.2 (192.168.64.2) port 32321 (#0)
INFO {"server_id":"NAM5ONG5A3GWTPVMJVKWMM5IM445NTV6E6FC43KTY76SYVJPSREDQB7U",
"server_name":"NAM5ONG5A3GWTPVMJVKWMM5IM445NTV6E6FC43KTY76SYVJPSREDQB7U",
"version":"2.1.7","proto":1,"git_commit":"bf0930ee","go":"go1.13.4","host":"0.0.0.0",
"port":4222,"max_payload":1048576,"client_id":4,"client_ip":"10.116.0.1"}
```