### PR TITLE
Added ability to send to external FHIR servers

### DIFF
--- a/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
@@ -9,13 +9,10 @@ import com.linuxforhealth.connect.processor.MetaDataProcessor;
 import com.linuxforhealth.connect.support.CamelContextSupport;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.Base64;
 
 import org.apache.camel.AggregationStrategy;
-import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
-import org.apache.camel.LoggingLevel;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +82,7 @@ public class FhirR4RouteBuilder extends BaseRouteBuilder {
             
             // Form the URIs for this resource type from the baseURIs
             for (String uri : uris) {
-                if (!uri.substring(uri.length() - 1).equals("/")) uri += "/";
+                if (!uri.endsWith("/")) uri += "/";
                 uri += resource;
                 if (!headerStr.equals("")) headerStr += ",";
                 headerStr += uri;

--- a/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
@@ -68,7 +68,9 @@ public class FhirR4RouteBuilder extends BaseRouteBuilder {
         from(EXTERNAL_FHIR_ROUTE_URI)
         .routeId(EXTERNAL_FHIR_ROUTE_ID)
         .choice()
-			.when(simple("${properties:lfh.connect.fhir-r4.externalservers:doesnotexist} == 'doesnotexist' || ${properties:lfh.connect.fhir-r4.externalservers:doesnotexist} == ''"))
+			.when(simple("${properties:lfh.connect.fhir-r4.externalservers:doesnotexist} == 'doesnotexist'"))
+				.stop()
+            .when(simple("${properties:lfh.connect.fhir-r4.externalservers:doesnotexist} == ''"))
 				.stop()
         .end()
         .process(exchange -> {

--- a/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
@@ -9,14 +9,29 @@ import com.linuxforhealth.connect.processor.MetaDataProcessor;
 import com.linuxforhealth.connect.support.CamelContextSupport;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Base64;
+
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Defines a FHIR R4 REST Processing route
  */
 public class FhirR4RouteBuilder extends BaseRouteBuilder {
 
+     private final Logger logger = LoggerFactory.getLogger(FhirR4RouteBuilder.class);
+
     public final static String ROUTE_ID = "fhir-r4";
     public final static String ROUTE_PRODUCER_ID = "fhir-r4-producer-store-and-notify";
+    public final static String EXTERNAL_FHIR_ROUTE_URI = "direct:toExternalFhirServers";
+    public final static String EXTERNAL_FHIR_ROUTE_ID = "external-fhir-servers";
+    public final static String EXTERNAL_FHIR_PRODUCER_ID = "lfh-external-fhir-producer";
 
     @Override
     protected String getRoutePropertyNamespace() {
@@ -40,6 +55,55 @@ public class FhirR4RouteBuilder extends BaseRouteBuilder {
                 .marshal().fhirJson("R4")
                 .process(new MetaDataProcessor(routePropertyNamespace))
                 .to(LinuxForHealthRouteBuilder.STORE_AND_NOTIFY_CONSUMER_URI)
-                .id(ROUTE_PRODUCER_ID);
+                .id(ROUTE_PRODUCER_ID)
+                .to(EXTERNAL_FHIR_ROUTE_URI);
+
+        /*
+         * Use the recipientList eip to optionally send data to one or more external fhir servers when 
+         * sending FHIR resources to Linus for Health. 
+         
+         * Set the lfh.connect.fhir-r4.externalservers property to a comma-delimted list of servers to 
+         * configure this feature.  Example:
+         * lfh.connect.fhir-r4.externalservers=http://localhost:9081/fhir-server/api/v4,http://localhost:9083/fhir-server/api/v4
+         *
+         * If lfh.connect.fhir-r4.externalservers does not exist or is not defined, no exception will be logged.
+         */ 
+        from(EXTERNAL_FHIR_ROUTE_URI)
+        .routeId(EXTERNAL_FHIR_ROUTE_ID)
+        .doTry()
+            .process(exchange -> {
+                String baseURIs = simple("{{lfh.connect.fhir-r4.externalservers}}").evaluate(exchange, String.class);
+                if (!baseURIs.equals("") && baseURIs != null) {
+                    String resource = exchange.getIn().getHeader("resource", String.class);
+                    String[] uris = baseURIs.split(",");
+                    String headerStr = "";
+                    
+                    // Form the URIs for this resource type from the baseURIs
+                    for (String uri : uris) {
+                        if (!uri.substring(uri.length() - 1).equals("/")) uri += "/";
+                        uri += resource;
+                        if (!headerStr.equals("")) headerStr += ",";
+                        headerStr += uri;
+                    }
+
+                    // Decode the data and set as message body
+                    JSONObject msg = new JSONObject(exchange.getIn().getBody(String.class));
+                    byte[] body = Base64.getDecoder().decode(msg.getString("data"));
+                    exchange.getIn().setBody(body);
+
+                    // Set up for the recipient list outbound calls
+                    exchange.getIn().removeHeaders("Camel*");
+                    exchange.getIn().setHeader(Exchange.HTTP_METHOD, "POST");
+                    logger.info("Sending message to recipientList {}", headerStr);
+                    exchange.getIn().setHeader("recipientList", headerStr);
+                }
+            })
+        .doCatch(CamelExecutionException.class)
+        .doCatch(Exception.class)
+            .log(LoggingLevel.ERROR, logger, exceptionMessage().toString())
+        .end()
+        .recipientList(header("recipientList"))
+        .ignoreInvalidEndpoints()
+        .id(EXTERNAL_FHIR_PRODUCER_ID);
     }
 }

--- a/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
@@ -60,9 +60,9 @@ public class FhirR4RouteBuilder extends BaseRouteBuilder {
 
         /*
          * Use the recipientList eip to optionally send data to one or more external fhir servers when 
-         * sending FHIR resources to Linus for Health. 
+         * sending FHIR resources to Linux for Health. 
          
-         * Set the lfh.connect.fhir-r4.externalservers property to a comma-delimted list of servers to 
+         * Set the lfh.connect.fhir-r4.externalservers property to a comma-delimited list of servers to 
          * configure this feature.  Example:
          * lfh.connect.fhir-r4.externalservers=http://localhost:9081/fhir-server/api/v4,http://localhost:9083/fhir-server/api/v4
          *
@@ -70,40 +70,81 @@ public class FhirR4RouteBuilder extends BaseRouteBuilder {
          */ 
         from(EXTERNAL_FHIR_ROUTE_URI)
         .routeId(EXTERNAL_FHIR_ROUTE_ID)
-        .doTry()
-            .process(exchange -> {
-                String baseURIs = simple("{{lfh.connect.fhir-r4.externalservers}}").evaluate(exchange, String.class);
-                if (!baseURIs.equals("") && baseURIs != null) {
-                    String resource = exchange.getIn().getHeader("resource", String.class);
-                    String[] uris = baseURIs.split(",");
-                    String headerStr = "";
-                    
-                    // Form the URIs for this resource type from the baseURIs
-                    for (String uri : uris) {
-                        if (!uri.substring(uri.length() - 1).equals("/")) uri += "/";
-                        uri += resource;
-                        if (!headerStr.equals("")) headerStr += ",";
-                        headerStr += uri;
-                    }
-
-                    // Decode the data and set as message body
-                    JSONObject msg = new JSONObject(exchange.getIn().getBody(String.class));
-                    byte[] body = Base64.getDecoder().decode(msg.getString("data"));
-                    exchange.getIn().setBody(body);
-
-                    // Set up for the recipient list outbound calls
-                    exchange.getIn().removeHeaders("Camel*");
-                    exchange.getIn().setHeader(Exchange.HTTP_METHOD, "POST");
-                    logger.info("Sending message to recipientList {}", headerStr);
-                    exchange.getIn().setHeader("recipientList", headerStr);
-                }
-            })
-        .doCatch(CamelExecutionException.class)
-        .doCatch(Exception.class)
-            .log(LoggingLevel.ERROR, logger, exceptionMessage().toString())
+        .choice()
+			.when(simple("${properties:lfh.connect.fhir-r4.externalservers:doesnotexist} == 'doesnotexist' || ${properties:lfh.connect.fhir-r4.externalservers:doesnotexist} == ''"))
+				.stop()
         .end()
+        .process(exchange -> {
+            String baseURIs = simple("{{lfh.connect.fhir-r4.externalservers}}").evaluate(exchange, String.class);
+            String resource = exchange.getIn().getHeader("resource", String.class);
+            String[] uris = baseURIs.split(",");
+            String headerStr = "";
+
+            // Save off the existing result in a property
+            exchange.setProperty("result", exchange.getIn().getBody(String.class));
+            
+            // Form the URIs for this resource type from the baseURIs
+            for (String uri : uris) {
+                if (!uri.substring(uri.length() - 1).equals("/")) uri += "/";
+                uri += resource;
+                if (!headerStr.equals("")) headerStr += ",";
+                headerStr += uri;
+            }
+
+            // Decode the data and set as message body
+            JSONObject msg = new JSONObject(exchange.getIn().getBody(String.class));
+            byte[] body = Base64.getDecoder().decode(msg.getString("data"));
+            exchange.getIn().setBody(body);
+
+            // Set up for the recipient list outbound calls
+            exchange.getIn().removeHeaders("Camel*");
+            exchange.getIn().setHeader(Exchange.HTTP_METHOD, "POST");
+            exchange.getIn().setHeader("Prefer", "return=OperationOutcome");
+            logger.info("Sending message to recipientList {}", headerStr);
+            exchange.getIn().setHeader("recipientList", headerStr);
+        })
         .recipientList(header("recipientList"))
         .ignoreInvalidEndpoints()
+        .aggregationStrategy(new AggregationStrategy() {
+            public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+                if (oldExchange == null) {
+                    // Get the original result - the data store location
+                    String result = newExchange.getProperty("result", String.class);
+                    JSONObject resultObj = new JSONObject(result);
+
+                    // Add the location header to the new result
+                    JSONObject msg = addHeaderToResult(newExchange);
+
+                    // Create JSONObject[] and add new result to it
+                    JSONObject[] resultArray = new JSONObject[1];
+                    resultArray[0] = msg;
+
+                    // Place both results in a new JSON object & set that as the result
+                    JSONObject metaResult = new JSONObject();
+                    metaResult.put("DataStoreResult", resultObj);
+                    metaResult.put("ExternalServerResult", resultArray);
+                    newExchange.getIn().setBody(metaResult.toString());
+                    return newExchange;
+                }
+
+                // Get the new result and add the location header
+                JSONObject msg = addHeaderToResult(newExchange);
+
+                // Get the meta result from the old exchange, add new result and set as body
+                JSONObject metaResult = new JSONObject(oldExchange.getIn().getBody(String.class));
+                JSONObject newMeta = metaResult.append("ExternalServerResult", msg);
+                oldExchange.getIn().setBody(newMeta.toString());
+                return oldExchange;
+            }
+        })
         .id(EXTERNAL_FHIR_PRODUCER_ID);
+    }
+
+    private JSONObject addHeaderToResult(Exchange exchange) {
+        JSONObject msg = new JSONObject();
+        JSONObject result = new JSONObject(exchange.getIn().getBody(String.class));
+        msg.put("Location", exchange.getIn().getHeader("Location", String.class));
+        msg.put("Result", result);
+        return msg;
     }
 }

--- a/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/FhirR4RouteBuilder.java
@@ -12,7 +12,6 @@ import com.linuxforhealth.connect.support.ExternalServerAggregationStrategy;
 import java.net.URI;
 import java.util.Base64;
 
-import org.apache.camel.AggregationStrategy;
 import org.apache.camel.Exchange;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/src/main/java/com/linuxforhealth/connect/support/ExternalServerAggregationStrategy.java
+++ b/src/main/java/com/linuxforhealth/connect/support/ExternalServerAggregationStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.linuxforhealth.connect.support;
+
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.Exchange;
+import org.json.JSONObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Aggregate results from multiple servers, as well as LFH data storage result.
+ */
+public class ExternalServerAggregationStrategy implements AggregationStrategy {
+
+    public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+        if (oldExchange == null) {
+            // Get the original result - the data store location
+            String result = newExchange.getProperty("result", String.class);
+            JSONObject resultObj = new JSONObject(result);
+
+            // Add the location header to the new result
+            JSONObject msg = addHeaderToResult(newExchange);
+
+            // Create JSONObject[] and add new result to it
+            JSONObject[] resultArray = new JSONObject[1];
+            resultArray[0] = msg;
+
+            // Place both results in a new JSON object & set that as the result
+            JSONObject metaResult = new JSONObject();
+            metaResult.put("DataStoreResult", resultObj);
+            metaResult.put("ExternalServerResult", resultArray);
+            newExchange.getIn().setBody(metaResult.toString());
+            return newExchange;
+        }
+
+        // Get the new result and add the location header
+        JSONObject msg = addHeaderToResult(newExchange);
+
+        // Get the meta result from the old exchange, add new result and set as body
+        JSONObject metaResult = new JSONObject(oldExchange.getIn().getBody(String.class));
+        JSONObject newMeta = metaResult.append("ExternalServerResult", msg);
+        oldExchange.getIn().setBody(newMeta.toString());
+        return oldExchange;
+    }
+
+    private JSONObject addHeaderToResult(Exchange exchange) {
+        JSONObject msg = new JSONObject();
+        JSONObject result = new JSONObject(exchange.getIn().getBody(String.class));
+        msg.put("Location", exchange.getIn().getHeader("Location", String.class));
+        msg.put("Result", result);
+        return msg;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,7 @@ lfh.connect.fhir-r4.port=8080
 lfh.connect.fhir-r4.uri=http://{{lfh.connect.fhir-r4.host}}:{{lfh.connect.fhir-r4.port}}/fhir/r4
 lfh.connect.fhir-r4.dataformat=fhir-r4
 lfh.connect.fhir-r4.messagetype=\${header.resource}
+lfh.connect.fhir-r4.externalservers=
 
 lfh.connect.acd.auth=authMethod=Basic&authUsername=apikey&authPassword=ENC(3XsVRVv9eVphHv+CAm2sGkwKvltlrkhqBOFVXiYO89btdklYEsdu0w==)
 lfh.connect.acd.version=2020-07-01

--- a/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthExternalFhirServersTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/LinuxForHealthExternalFhirServersTest.java
@@ -1,0 +1,102 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.linuxforhealth.connect.builder;
+
+import com.linuxforhealth.connect.support.LFHKafkaConsumer;
+import com.linuxforhealth.connect.support.ExternalServerAggregationStrategy;
+import com.linuxforhealth.connect.support.TestUtils;
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+/**
+ * Tests {@link LinuxForHealthRouteBuilder#REMOTE_EVENTS_ROUTE_ID}
+ */
+public class LinuxForHealthExternalFhirServersTest extends RouteTestSupport {
+
+    private MockEndpoint mockResult;
+
+    /**
+     * Provides properties to support mocking data and messaging components.
+     * @return {@link Properties}
+     */
+    @Override
+    protected Properties useOverridePropertiesWithPropertiesComponent() {
+        Properties props = super.useOverridePropertiesWithPropertiesComponent();
+
+        props.setProperty("lfh.connect.test.uri", "direct:test-notify");
+        props.setProperty("lfh.connect.messaging.uri", "mock:messaging");
+        props.setProperty("lfh.connect.datastore.remote-events.consumer.uri", "direct:remote-events");
+        props.setProperty("lfh.connect.fhir-r4.externalservers", "http://localhost:9081/fhir-server/api/v4");
+        return props;
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new FhirR4RouteBuilder();
+    }
+
+    /**
+     * Overriden to register beans, apply advice, and register a mock endpoint
+     * @throws Exception if an error occurs applying advice
+     */
+    @BeforeEach
+    @Override
+    protected void configureContext() throws Exception {
+
+        setProducerResponseByToString(FhirR4RouteBuilder.EXTERNAL_FHIR_ROUTE_ID,
+                "recipientList*",
+                "fhir",
+                "ext-fhir-server-mock-result.json");
+
+        addLast(FhirR4RouteBuilder.EXTERNAL_FHIR_ROUTE_ID, "mock:result");
+    
+        context.getRegistry().bind("LFHKafkaConsumer", new LFHKafkaConsumer());
+        super.configureContext();
+
+        mockResult = MockEndpoint.resolve(context, "mock:result");
+    }
+
+    /**
+     * Tests {@link LinuxForHealthRouteBuilder#REMOTE_EVENTS_ROUTE_ID}
+     * @throws Exception
+     */
+    @Test
+    void testRoute() throws Exception {
+
+        // Get the string that represents the result of the fhir-r4 route
+        String inputMessage = context
+            .getTypeConverter()
+            .convertTo(String.class, TestUtils.getMessage("fhir", "ext-fhir-server-route-input.json"))
+            .replace(System.lineSeparator(), "");
+
+        String expectedMessage = context
+            .getTypeConverter()
+            .convertTo(String.class, TestUtils.getMessage("fhir", "ext-fhir-server-expected-msg.json"))
+            .replace(System.lineSeparator(), "");
+
+        fluentTemplate.to(FhirR4RouteBuilder.EXTERNAL_FHIR_ROUTE_URI)
+            .withBody(inputMessage)
+            .withHeader("resource", "Patient")
+            .send();
+
+        // Pass the resulting exchange to the aggregation strategy (not included in the mocked route)
+        AggregationStrategy as = new ExternalServerAggregationStrategy();
+        as.aggregate(null, mockResult.getExchanges().get(0));
+
+        mockResult.expectedMessageCount(1);
+        mockResult.expectedBodiesReceived(expectedMessage);
+        mockResult.expectedPropertyReceived("dataStoreUri", "kafka:FHIR-R4_PATIENT?brokers=localhost:9094");
+        mockResult.expectedPropertyReceived("dataFormat", "FHIR-R4");
+        mockResult.expectedPropertyReceived("messageType", "PATIENT");
+        mockResult.expectedPropertyReceived("routeId", "fhir-r4");
+        mockResult.assertIsSatisfied();
+    }
+}

--- a/src/test/resources/messages/fhir/ext-fhir-server-expected-msg.json
+++ b/src/test/resources/messages/fhir/ext-fhir-server-expected-msg.json
@@ -1,0 +1,38 @@
+{
+    "ExternalServerResult": [
+        {
+            "Location": "http://localhost:9081/fhir-server/api/v4/Patient/83752bc2-6c62-4c67-ab16-bce251f95da4/_history/1",
+            "Result": {
+                "issue": [
+                    {
+                        "severity": "information",
+                        "code": "informational",
+                        "expression": [
+                            "<no expression>"
+                        ],
+                        "details": {
+                            "text": "The create request resource included id: '001'; this id has been replaced"
+                        }
+                    }
+                ],
+                "resourceType": "OperationOutcome"
+            }
+        }
+    ],
+    "DataStoreResult": {
+        "data": "eyJyZXNvdXJjZVR5cGUiOiJQYXRpZW50IiwiaWQiOiIwMDEiLCJtZXRhIjp7InRhZyI6W3sic3lzdGVtIjoiaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS92My1BY3RSZWFzb24iLCJjb2RlIjoiSFRFU1QiLCJkaXNwbGF5IjoidGVzdCBoZWFsdGggZGF0YSJ9XX0sInRleHQiOnsic3RhdHVzIjoiZ2VuZXJhdGVkIiwiZGl2IjoiPGRpdiB4bWxucz1cImh0dHA6Ly93d3cudzMub3JnLzE5OTkveGh0bWxcIj5cbiAgICAgIFxuICAgICAgPHA+UGF0aWVudCBEYWlzeSBEVUNLIEAgQWNtZSBIZWFsdGhjYXJlLCBJbmMuIE1SID0gNjU0MzIxPC9wPlxuICAgIFxuICAgIDwvZGl2PiJ9LCJpZGVudGlmaWVyIjpbeyJ1c2UiOiJ1c3VhbCIsInR5cGUiOnsiY29kaW5nIjpbeyJzeXN0ZW0iOiJodHRwOi8vdGVybWlub2xvZ3kuaGw3Lm9yZy9Db2RlU3lzdGVtL3YyLTAyMDMiLCJjb2RlIjoiTVIifV19LCJzeXN0ZW0iOiJ1cm46b2lkOjAuMS4yLjMuNC41LjYuNyIsInZhbHVlIjoiNjU0MzIxIn1dLCJhY3RpdmUiOnRydWUsIm5hbWUiOlt7InVzZSI6Im9mZmljaWFsIiwiZmFtaWx5IjoiRHVjayIsImdpdmVuIjpbIkRhaXN5Il19XSwiZ2VuZGVyIjoiZmVtYWxlIiwibWFuYWdpbmdPcmdhbml6YXRpb24iOnsicmVmZXJlbmNlIjoiT3JnYW5pemF0aW9uLzEiLCJkaXNwbGF5IjoiQUNNRSBIZWFsdGhjYXJlLCBJbmMifSwibGluayI6W3sib3RoZXIiOnsicmVmZXJlbmNlIjoiUGF0aWVudC9wYXQxIn0sInR5cGUiOiJzZWVhbHNvIn1dfQ==",
+        "meta": {
+            "dataStoreUri": "kafka:FHIR-R4_PATIENT?brokers=localhost:9094",
+            "routeUri": "jetty:http://0.0.0.0:8080/fhir/r4/Patient?httpMethodRestrict=POST",
+            "routeId": "fhir-r4",
+            "messageType": "PATIENT",
+            "dataFormat": "FHIR-R4",
+            "dataRecordLocation": [
+                "FHIR-R4_PATIENT:0:25"
+            ],
+            "uuid": "e6c290b7-6a60-4632-a2d1-21ad5039b438",
+            "timestamp": 1600183871,
+            "status": "success"
+        }
+    }
+}

--- a/src/test/resources/messages/fhir/ext-fhir-server-mock-result.json
+++ b/src/test/resources/messages/fhir/ext-fhir-server-mock-result.json
@@ -1,0 +1,15 @@
+{
+    "issue": [
+        {
+            "severity": "information",
+            "code": "informational",
+            "expression": [
+                "<no expression>"
+            ],
+            "details": {
+                "text": "The create request resource included id: '001'; this id has been replaced"
+            }
+        }
+    ],
+    "resourceType": "OperationOutcome"
+}

--- a/src/test/resources/messages/fhir/ext-fhir-server-route-input.json
+++ b/src/test/resources/messages/fhir/ext-fhir-server-route-input.json
@@ -1,0 +1,16 @@
+{
+    "data": "eyJyZXNvdXJjZVR5cGUiOiJQYXRpZW50IiwiaWQiOiIwMDEiLCJtZXRhIjp7InRhZyI6W3sic3lzdGVtIjoiaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS92My1BY3RSZWFzb24iLCJjb2RlIjoiSFRFU1QiLCJkaXNwbGF5IjoidGVzdCBoZWFsdGggZGF0YSJ9XX0sInRleHQiOnsic3RhdHVzIjoiZ2VuZXJhdGVkIiwiZGl2IjoiPGRpdiB4bWxucz1cImh0dHA6Ly93d3cudzMub3JnLzE5OTkveGh0bWxcIj5cbiAgICAgIFxuICAgICAgPHA+UGF0aWVudCBEYWlzeSBEVUNLIEAgQWNtZSBIZWFsdGhjYXJlLCBJbmMuIE1SID0gNjU0MzIxPC9wPlxuICAgIFxuICAgIDwvZGl2PiJ9LCJpZGVudGlmaWVyIjpbeyJ1c2UiOiJ1c3VhbCIsInR5cGUiOnsiY29kaW5nIjpbeyJzeXN0ZW0iOiJodHRwOi8vdGVybWlub2xvZ3kuaGw3Lm9yZy9Db2RlU3lzdGVtL3YyLTAyMDMiLCJjb2RlIjoiTVIifV19LCJzeXN0ZW0iOiJ1cm46b2lkOjAuMS4yLjMuNC41LjYuNyIsInZhbHVlIjoiNjU0MzIxIn1dLCJhY3RpdmUiOnRydWUsIm5hbWUiOlt7InVzZSI6Im9mZmljaWFsIiwiZmFtaWx5IjoiRHVjayIsImdpdmVuIjpbIkRhaXN5Il19XSwiZ2VuZGVyIjoiZmVtYWxlIiwibWFuYWdpbmdPcmdhbml6YXRpb24iOnsicmVmZXJlbmNlIjoiT3JnYW5pemF0aW9uLzEiLCJkaXNwbGF5IjoiQUNNRSBIZWFsdGhjYXJlLCBJbmMifSwibGluayI6W3sib3RoZXIiOnsicmVmZXJlbmNlIjoiUGF0aWVudC9wYXQxIn0sInR5cGUiOiJzZWVhbHNvIn1dfQ==",
+    "meta": {
+        "dataStoreUri": "kafka:FHIR-R4_PATIENT?brokers=localhost:9094",
+        "routeUri": "jetty:http://0.0.0.0:8080/fhir/r4/Patient?httpMethodRestrict=POST",
+        "routeId": "fhir-r4",
+        "messageType": "PATIENT",
+        "dataFormat": "FHIR-R4",
+        "dataRecordLocation": [
+            "FHIR-R4_PATIENT:0:25"
+        ],
+        "uuid": "e6c290b7-6a60-4632-a2d1-21ad5039b438",
+        "timestamp": 1600183871,
+        "status": "success"
+    }
+}


### PR DESCRIPTION
This PR adds the ability to send FHIR resources to the standard LFH FHIR endpoint, then optional send to external FHIR servers based on a property configuration.