### PR TITLE
updating test cases to use System line separator

### DIFF
--- a/src/test/java/com/linuxforhealth/connect/builder/FhirR4RouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/FhirR4RouteTest.java
@@ -53,7 +53,7 @@ public class FhirR4RouteTest extends RouteTestSupport {
         String testMessage = context
                 .getTypeConverter()
                 .convertTo(String.class, TestUtils.getMessage("fhir", "fhir-r4-patient-bundle.json"))
-                .replace("\n", "");
+                .replace(System.lineSeparator(), "");
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 

--- a/src/test/java/com/linuxforhealth/connect/builder/Hl7v2RouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/Hl7v2RouteTest.java
@@ -61,7 +61,7 @@ public class Hl7v2RouteTest extends RouteTestSupport {
         String testMessage = context
                 .getTypeConverter()
                 .convertTo(String.class, TestUtils.getMessage("hl7", "ADT_A01.txt"))
-                .replace("\n", "\r");
+                .replace(System.lineSeparator(), "\r");
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 


### PR DESCRIPTION
This PR removes the "hard coded" line separator used in the FHIR R4 and HL7 unit tests to ensure that the tests will complete successfully on Windows. 

I tested the issue by running a clean build (with tests) in a Windows 10 VM
CMD Test
```
c:\Users\User\lfh\connect>gradlew.bat clean build
Starting a Gradle Daemon, 1 incompatible and 2 stopped Daemons could not be reused, use --status for details

> Task :compileJava
Note: C:\Users\User\lfh\connect\src\main\java\com\linuxforhealth\connect\builder\BlueButton20RouteBuilder.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

BUILD SUCCESSFUL in 58s
11 actionable tasks: 11 executed
```

Git Bash Test
```
User@WinDev2008Eval MINGW64 ~/lfh/connect (windows-test-cases)
$ ./gradlew clean build

> Task :compileJava
Note: C:\Users\User\lfh\connect\src\main\java\com\linuxforhealth\connect\builder\BlueButton20RouteBuilder.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

BUILD SUCCESSFUL in 40s
11 actionable tasks: 11 executed
```