### PR TITLE
Update CI to Support Java 11 (LTS) and Java 14

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,7 +1,10 @@
+# (C) Copyright IBM Corp. 2020
+# SPDX-License-Identifier: Apache-2.0
+#
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: Linux for Health CI
 
 on:
   push:
@@ -10,17 +13,21 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  compile:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [1.8, 11, 14]
 
+  build:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew clean build


### PR DESCRIPTION
This PR updates LFH's GitHub Action CI to include running tests against Java 11 and 14.