### PR TITLE
Continuous Integration - Support Failed Test Logging and Dependency Caching

### DIFF
--- a/.github/workflows/lfh-ci-actions.yml
+++ b/.github/workflows/lfh-ci-actions.yml
@@ -24,7 +24,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -113,3 +113,9 @@ processResources {
         expand(project.properties)
     }
 }
+
+test {
+    testLogging {
+        events "failed"
+    }
+}


### PR DESCRIPTION
This PR updates the LFH CI GitHub action to support:

- logging error information related to failed tests
- support dependency caching on GitHub Action Infrastructure