### PR TITLE
Snapshot Image Deployment to DockerHub

### DIFF
--- a/.github/workflows/lfh-ci-actions.yml
+++ b/.github/workflows/lfh-ci-actions.yml
@@ -1,12 +1,10 @@
 # (C) Copyright IBM Corp. 2020
 # SPDX-License-Identifier: Apache-2.0
-#
 
 name: Linux for Health Continuous Integration
+description: Runs CI tests with a PR is submitted against the Linux For Health master branch.
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/lfh-ci-actions.yml
+++ b/.github/workflows/lfh-ci-actions.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Linux for Health Continuous Integration
-description: Runs CI tests with a PR is submitted against the Linux For Health master branch.
+# Runs CI tests with a PR is submitted against the Linux For Health master branch.
 
 on:
   pull_request:

--- a/.github/workflows/lfh-publish-snapshot-image.yml
+++ b/.github/workflows/lfh-publish-snapshot-image.yml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Linux for Health Publish Snapshot Image
-description: Publishes a snapshot image to linuxforhealth/connect when a commit is pushed to the Linux for Health master branch.
+# Publishes a snapshot image to linuxforhealth/connect when a commit is pushed to the
+# Linux for Health master branch.
 
 on:
   push:

--- a/.github/workflows/lfh-publish-snapshot-image.yml
+++ b/.github/workflows/lfh-publish-snapshot-image.yml
@@ -1,0 +1,35 @@
+# (C) Copyright IBM Corp. 2020
+# SPDX-License-Identifier: Apache-2.0
+
+name: Linux for Health Publish Snapshot Image
+description: Publishes a snapshot image to linuxforhealth/connect when a commit is pushed to the Linux for Health master branch.
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  push_to_registry:
+    name: Publish Snapshot Image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout LFH Project
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          tags: linuxforhealth/connect:snapshot


### PR DESCRIPTION
This PR implements a GitHub action to support continuous deployment to Docker Hub for LFH Connect "snapshot" images. The action fires when code is pushed/committed to the master branch.