### PR TITLE
LFH CD Round III

### DIFF
--- a/.github/workflows/lfh-publish-snapshot-image.yml
+++ b/.github/workflows/lfh-publish-snapshot-image.yml
@@ -28,8 +28,8 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew build
+      - name: Build with Gradle (skip tests)
+        run: ./gradlew build -x test
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
This PR updates the gradle command to skip tests. Tests aren't utilized since they are run as part of the CI process.