### PR TITLE
Updating image publishing workflow to support published GitHub releases

### DIFF
--- a/.github/workflows/lfh-publish-image.yml
+++ b/.github/workflows/lfh-publish-image.yml
@@ -7,8 +7,9 @@ name: Linux for Health Publish Snapshot Image
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
+  release:
+    types: [published]
 jobs:
   push_to_registry:
     name: Publish Snapshot Image to Docker Hub
@@ -34,12 +35,20 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build and push
+      - name: Build And Push Snapshot Image
+        if:  ${{ env.GITHUB_EVENT_NAME == 'push' }}
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -48,3 +57,14 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64,linux/s390x
           tags: linuxforhealth/connect:snapshot
+      - name: Build And Push Image Tag
+        if:  ${{ env.GITHUB_EVENT_NAME == 'published' }}
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          repository: linuxforhealth/connect
+          auto_tag: true


### PR DESCRIPTION
This PR updates the "publish snapshot image" workflow for general purpose of publishing snapshot and published tag releases.