### PR TITLE
LinuxForHealth Publish To Docker Action Fails

### DIFF
--- a/.github/workflows/lfh-publish-image.yml
+++ b/.github/workflows/lfh-publish-image.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle (skip tests)
-        run: ./gradlew build -x test
+        run: ./gradlew clean build -x test
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:


### PR DESCRIPTION
This PR updates the LinuxForHealth Publish Image GitHub Action to resolve an issue with docker buildx.