### PR TITLE
GitHub Docker Publish Fix

### DIFF
--- a/.github/workflows/lfh-publish-image.yml
+++ b/.github/workflows/lfh-publish-image.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle (skip tests)
-        run: ./gradlew clean build -x test
+        run: ./gradlew build -x test
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -53,8 +53,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          dockerfile: Dockerfile
-          path: .
+          context: .
           push: true
           platforms: linux/amd64,linux/arm64,linux/s390x
           tags: ${{ steps.generate_tags.outputs.lfh_tags }}

--- a/.github/workflows/lfh-publish-image.yml
+++ b/.github/workflows/lfh-publish-image.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: .
           push: true
           platforms: linux/amd64,linux/arm64,linux/s390x
           tags: ${{ steps.generate_tags.outputs.lfh_tags }}

--- a/.github/workflows/lfh-publish-image.yml
+++ b/.github/workflows/lfh-publish-image.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle (skip tests)
-        run: ./gradlew build -x test
+        run: ./gradlew clean build -x test
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:


### PR DESCRIPTION
This PR updated the lfh-publish-image.yml/actions file to address an issue with `docker buildx` It appears that the action's arguments were updated without bumping the version, which caused this action to fail.