### PR TITLE
Remove commons-codec dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,7 @@ dependencies {
     implementation group: 'org.apache.camel', name: 'camel-rest', version: project.camelVersion
     implementation group: 'org.apache.camel', name: 'camel-support', version: project.camelVersion
 
-    // Java utils (base64 encoding, OS type)
-    implementation group: 'commons-codec', name: 'commons-codec', version: project.commonsVersion
+    // Java utils (OS type)
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: project.commonsLang3Version
 
     // data format support

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,6 @@ hapiHl7Version=2.3
 hapiFhirVersion=5.0.2
 hapiFhirConvertorVersion=5.1.0-SNAPSHOT
 
-# ipfs
-ipfsClientVersion=1.0.0.Beta4
-ipfsApiVersion=v1.2.2
-
 # logging
 logbackVersion=1.2.3
 slf4jVersion=1.7.30


### PR DESCRIPTION
This PR removes the commons-code dependency and some "unused" IPFS build properties. The former is no longer needed as base 64 encoding/decoding is supported via the JRE. The latter is not needed since we're not currently integrating with IPFS.

I tested locally by running the tests and then firing up the stack to launch the "hello world" tutorial.