### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ junitVersion=5.6.2
 # hapi hl7 and fhir client versions
 hapiHl7Version=2.3
 hapiFhirVersion=5.0.2
-hapiFhirConvertorVersion=5.1.0-SNAPSHOT
+hapiFhirConvertorVersion=5.1.0
 
 # ipfs
 ipfsClientVersion=1.0.0.Beta4


### PR DESCRIPTION
Change `hapiFhirConvertorVersion` setting from `5.1.0-SNAPSHOT` to `5.1.0`.
The 5.1.0 snapshot is no longer available.