### PR TITLE
CCD Test Case Fix

### DIFF
--- a/.github/workflows/lfh-ci-actions.yml
+++ b/.github/workflows/lfh-ci-actions.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [1.8, 11]
+        java: [1.8]
     name: Linux for Health CI - OS ${{ matrix.os }} Java Version ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
@@ -31,4 +31,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew clean build

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,4 @@
  * in the user manual at https://docs.gradle.org/6.2.2/userguide/multi_project_builds.html
  */
 
-rootProject.name = 'linux-for-health-connect'
+rootProject.name = 'connect'

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -71,6 +71,7 @@ public class CcdRouteTest extends RouteTestSupport{
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 
+        mockErrorResult.expectedMessageCount(0);
         mockResult.expectedMessageCount(1);
         mockResult.expectedBodiesReceived(expectedMessage);
         mockResult.expectedPropertyReceived("dataStoreUri", "kafka:HL7-V3_CCD?brokers=localhost:9094");
@@ -82,6 +83,7 @@ public class CcdRouteTest extends RouteTestSupport{
                 .withBody(testMessage)
                 .send();
 
+        mockErrorResult.assertIsSatisfied();
         mockResult.assertIsSatisfied();
     }
 

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -44,18 +44,15 @@ public class CcdRouteTest extends RouteTestSupport{
     @BeforeEach
     @Override
     protected void configureContext() throws Exception {
-        mockProducerEndpoint(CcdRouteBuilder.ROUTE_ID,
+        mockResult = mockProducerEndpoint(CcdRouteBuilder.ROUTE_ID,
             LinuxForHealthRouteBuilder.STORE_AND_NOTIFY_CONSUMER_URI,
             "mock:result");
 
-        mockProducerEndpoint(CcdRouteBuilder.ROUTE_ID,
-            LinuxForHealthRouteBuilder.ERROR_CONSUMER_URI,
-            "mock:error-result");
+        mockErrorResult = mockProducerEndpoint(CcdRouteBuilder.ROUTE_ID,
+                LinuxForHealthRouteBuilder.ERROR_CONSUMER_URI,
+                "mock:error-result");
 
         super.configureContext();
-
-        mockResult = MockEndpoint.resolve(context, "mock:result");
-        mockErrorResult = MockEndpoint.resolve(context, "mock:error-result");
     }
 
     /**
@@ -71,10 +68,6 @@ public class CcdRouteTest extends RouteTestSupport{
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 
-        if (mockErrorResult.getExchanges().size() > 0) {
-            String errorMessage = mockErrorResult.getExchanges().get(0).getMessage(String.class);
-            Assertions.fail("Received error " + errorMessage);
-        }
         mockErrorResult.expectedMessageCount(0);
         mockResult.expectedMessageCount(1);
         mockResult.expectedBodiesReceived(expectedMessage);
@@ -87,7 +80,6 @@ public class CcdRouteTest extends RouteTestSupport{
                 .withBody(testMessage)
                 .send();
 
-        mockErrorResult.assertIsSatisfied();
         mockResult.assertIsSatisfied();
     }
 

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -4,7 +4,7 @@ import com.linuxforhealth.connect.support.TestUtils;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -89,7 +89,8 @@ public class CcdRouteTest extends RouteTestSupport{
         String testMessage = context
                 .getTypeConverter()
                 .convertTo(String.class, TestUtils.getMessage("ccd", "SampleCCDDocument.xml"))
-                .replaceAll(System.lineSeparator(), "").replaceAll("ClinicalDocument", "InvalidDocument");
+                .replaceAll("(?:>)(\\s*)<", "><")
+                .replaceAll("ClinicalDocument", "InvalidDocument");
 
         mockErrorResult.expectedMessageCount(1);
         mockResult.expectedMessageCount(0);

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -80,6 +80,7 @@ public class CcdRouteTest extends RouteTestSupport{
                 .withBody(testMessage)
                 .send();
 
+        mockErrorResult.assertIsSatisfied();
         mockResult.assertIsSatisfied();
     }
 

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -71,6 +71,7 @@ public class CcdRouteTest extends RouteTestSupport{
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 
+        mockErrorResult.expectedBodiesReceived("error message");
         mockErrorResult.expectedMessageCount(0);
         mockResult.expectedMessageCount(1);
         mockResult.expectedBodiesReceived(expectedMessage);

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -71,6 +71,10 @@ public class CcdRouteTest extends RouteTestSupport{
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 
+        if (mockErrorResult.getExchanges().size() > 0) {
+            String errorMessage = mockErrorResult.getExchanges().get(0).getMessage(String.class);
+            Assertions.fail("Received error " + errorMessage);
+        }
         mockErrorResult.expectedMessageCount(0);
         mockResult.expectedMessageCount(1);
         mockResult.expectedBodiesReceived(expectedMessage);

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -71,7 +71,6 @@ public class CcdRouteTest extends RouteTestSupport{
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 
-        mockErrorResult.expectedBodiesReceived("error message");
         mockErrorResult.expectedMessageCount(0);
         mockResult.expectedMessageCount(1);
         mockResult.expectedBodiesReceived(expectedMessage);

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -1,19 +1,15 @@
 package com.linuxforhealth.connect.builder;
 
-import com.linuxforhealth.connect.support.LFHKafkaConsumer;
 import com.linuxforhealth.connect.support.TestUtils;
-import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.support.processor.validation.SchemaValidationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Properties;
 
 /**
  * Tests {@link CcdRouteBuilder}
@@ -79,6 +75,11 @@ public class CcdRouteTest extends RouteTestSupport{
         fluentTemplate.to("http://0.0.0.0:8080/ccd")
                 .withBody(testMessage)
                 .send();
+
+        if (mockErrorResult.getExchanges().size() > 0) {
+            String errorMessage = mockErrorResult.getExchanges().get(0).getMessage(String.class);
+            Assertions.fail("Received error message " + errorMessage);
+        }
 
         mockErrorResult.assertIsSatisfied();
         mockResult.assertIsSatisfied();

--- a/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/CcdRouteTest.java
@@ -60,7 +60,7 @@ public class CcdRouteTest extends RouteTestSupport{
         String testMessage = context
                 .getTypeConverter()
                 .convertTo(String.class, TestUtils.getMessage("ccd", "SampleCCDDocument.xml"))
-                .replaceAll(System.lineSeparator(), "");
+                .replaceAll("(?:>)(\\s*)<", "><");
 
         String expectedMessage = Base64.getEncoder().encodeToString(testMessage.getBytes(StandardCharsets.UTF_8));
 
@@ -75,11 +75,6 @@ public class CcdRouteTest extends RouteTestSupport{
         fluentTemplate.to("http://0.0.0.0:8080/ccd")
                 .withBody(testMessage)
                 .send();
-
-        if (mockErrorResult.getExchanges().size() > 0) {
-            String errorMessage = mockErrorResult.getExchanges().get(0).getMessage(String.class);
-            Assertions.fail("Received error message " + errorMessage);
-        }
 
         mockErrorResult.assertIsSatisfied();
         mockResult.assertIsSatisfied();
@@ -97,11 +92,13 @@ public class CcdRouteTest extends RouteTestSupport{
                 .replaceAll(System.lineSeparator(), "").replaceAll("ClinicalDocument", "InvalidDocument");
 
         mockErrorResult.expectedMessageCount(1);
+        mockResult.expectedMessageCount(0);
 
         fluentTemplate.to("http://0.0.0.0:8080/ccd")
                 .withBody(testMessage)
                 .send();
 
+        mockResult.assertIsSatisfied();
         mockErrorResult.assertIsSatisfied();
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -23,8 +23,8 @@
     <!--
     Adjust the loggers below for the desired granularity
     -->
-    <logger name="com.linuxforhealth.connect" level="debug" />
-    <logger name="org.apache.camel" level="debug" />
+    <logger name="com.linuxforhealth.connect" level="info" />
+    <logger name="org.apache.camel" level="info" />
     <logger name="org.apache.camel.main" level="info" />
     <logger name="org.apache.camel.component" level="info" />
     <logger name="org.apache.kafka.consumer" level="warn" />

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -23,8 +23,8 @@
     <!--
     Adjust the loggers below for the desired granularity
     -->
-    <logger name="com.linuxforhealth.connect" level="info" />
-    <logger name="org.apache.camel" level="info" />
+    <logger name="com.linuxforhealth.connect" level="debug" />
+    <logger name="org.apache.camel" level="debug" />
     <logger name="org.apache.camel.main" level="info" />
     <logger name="org.apache.camel.component" level="info" />
     <logger name="org.apache.kafka.consumer" level="warn" />


### PR DESCRIPTION
This PR is used to monitor the problematic CCD Test Case.

The PR also contains a change which aligns the Gradle Root Project Name with the root directory of the project. This additional change will be benefit IDE setups (Eclipse) and is used to generate a diff so I can do an initial PR to monitor the test case.

Updated: The issue is that the sample document would "sometimes" fail validation. While I don't have a reason why this would occur as it would happen "sometimes" on Linux, and "other times" on Windows I was able to update the code we use to load the XML resource so that it worked for four runs in a row. Additional notes are on the PR updates.