### PR TITLE
Add Integration Profile for Docker Compose

### DIFF
--- a/container-support/compose/.env
+++ b/container-support/compose/.env
@@ -65,3 +65,24 @@ LFH_KONG_ADMIN_LISTEN="0.0.0.0:8001, 0.0.0.0:8444 ssl"
 LFH_KONG_STREAM_LISTEN=0.0.0.0:2575
 LFH_KONG_LOG_LEVEL=info
 LFH_KONG_PLUGINS="bundled"
+
+# IBM FHIR
+IBM_FHIR_IMAGE=docker.io/ibmcom/ibm-fhir-server:4.4.0
+IBM_FHIR_HTTP_PORT=9080
+IBM_FHIR_HTTPS_PORT=9443
+
+# MSFT FHIR SQL
+MSFT_FHIR_SQL_IMAGE=mcr.microsoft.com/mssql/server
+MSFT_FHIR_SQL_SA_PASSWORD=Super@Duper_Password20
+
+# MSFT FHIR
+MSFT_FHIR_IMAGE=docker.io/linxuforhealth/msft-fhir:20201028-2
+MSFT_FHIR_SECURITY_ENABLED="false"
+MSFT_FHIR_SQL_CONNECTION_STRING="Server=tcp:msft-fhir-sql,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=Super@Duper_Password20;MultipleActiveResultSets=False;Connection Timeout=30;"
+MSFT_FHIR_SQL_ALLOW_DB_CREATE="true"
+MSFT_FHIR_SQL_INITIALIZE="true"
+MSFT_FHIR_SQL_AUTO_UPDATE="true"
+MSFT_FHIR_DATASTORE="SqlServer"
+MSFT_FHIR_PORT=8080
+MSFT_FHIR_HOST_PORT=9090
+

--- a/container-support/compose/.env
+++ b/container-support/compose/.env
@@ -53,7 +53,6 @@ LFH_KONG_SERVICE_NAME=kong
 LFH_KONG_IMAGE=docker.io/linuxforhealth/kong:2.1.4
 LFH_KONG_DATABASE_TYPE=postgres
 LFH_KONG_DATABASE=kong
-LFH_KONG_PORT=8000
 LFH_KONG_SSL_PORT=8443
 LFH_KONG_ADMIN_PORT=8001
 LFH_KONG_ADMIN_SSL_PORT=8444
@@ -73,7 +72,7 @@ MSFT_FHIR_SQL_IMAGE=mcr.microsoft.com/mssql/server
 MSFT_FHIR_SQL_SA_PASSWORD=Super@Duper_Password20
 
 # MSFT FHIR
-MSFT_FHIR_IMAGE=docker.io/linxuforhealth/msft-fhir:20201028-2
+MSFT_FHIR_IMAGE=docker.io/linuxforhealth/msft-fhir:20201028-2-R4
 MSFT_FHIR_SECURITY_ENABLED="false"
 MSFT_FHIR_SQL_CONNECTION_STRING="Server=tcp:msft-fhir-sql,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=Super@Duper_Password20;MultipleActiveResultSets=False;Connection Timeout=30;"
 MSFT_FHIR_SQL_ALLOW_DB_CREATE="true"
@@ -82,4 +81,3 @@ MSFT_FHIR_SQL_AUTO_UPDATE="true"
 MSFT_FHIR_DATASTORE="SqlServer"
 MSFT_FHIR_PORT=8080
 MSFT_FHIR_HOST_PORT=9090
-

--- a/container-support/compose/README.md
+++ b/container-support/compose/README.md
@@ -27,6 +27,7 @@ docker-compose down -v
 ## Supported Profiles
 | Profile Name | Profile Description |
 | :--- | :--- |
-| dev | For local development use. Runs LFH supporting services with port mappings. |
-| server | For deployment environments or integrated testing. Includes the LFH connect application and supporting services. |
+| dev | For local development use where LFH connect is running locally outside of a container. |
+| integration | For local testing. Includes LFH connect and external services for end-to-end testing. | 
+| server | For deployment environments. Includes the LFH connect application and supporting services. |
 | pi | Similar to the server stack. Optimized for arm64/Raspberry Pi usage. |

--- a/container-support/compose/docker-compose.integration.yml
+++ b/container-support/compose/docker-compose.integration.yml
@@ -3,7 +3,6 @@ services:
   ibm-fhir:
     image: ${IBM_FHIR_IMAGE}
     ports:
-      - ${IBM_FHIR_HTTP_PORT}:${IBM_FHIR_HTTP_PORT}
       - ${IBM_FHIR_HTTPS_PORT}:${IBM_FHIR_HTTPS_PORT}
   msft-fhir:
     restart: on-failure

--- a/container-support/compose/docker-compose.integration.yml
+++ b/container-support/compose/docker-compose.integration.yml
@@ -1,0 +1,31 @@
+version: "3.7"
+services:
+  ibm-fhir:
+    image: ${IBM_FHIR_IMAGE}
+    ports:
+      - ${IBM_FHIR_HTTP_PORT}:${IBM_FHIR_HTTP_PORT}
+      - ${IBM_FHIR_HTTPS_PORT}:${IBM_FHIR_HTTPS_PORT}
+  msft-fhir:
+    restart: on-failure
+    image: ${MSFT_FHIR_IMAGE}
+    environment:
+      FHIRServer__Security__Enabled: ${MSFT_FHIR_SECURITY_ENABLED}
+      SqlServer__ConnectionString: ${MSFT_FHIR_SQL_CONNECTION_STRING}
+      SqlServer__AllowDatabaseCreation: ${MSFT_FHIR_SQL_ALLOW_DB_CREATE}
+      SqlServer__Initialize: ${MSFT_FHIR_SQL_INITIALIZE}
+      SqlServer__SchemaOptions__AutomaticUpdatesEnabled: ${MSFT_FHIR_SQL_AUTO_UPDATE}
+      DataStore: ${MSFT_FHIR_DATASTORE}
+    ports:
+      - ${MSFT_FHIR_HOST_PORT}:${MSFT_FHIR_PORT}
+    depends_on:
+      - msft-fhir-sql
+  msft-fhir-sql:
+    image: ${MSFT_FHIR_SQL_IMAGE}
+    environment:
+      SA_PASSWORD: ${MSFT_FHIR_SQL_SA_PASSWORD}
+      ACCEPT_EULA: "Y"
+    healthcheck:
+      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd","-U sa -P ${MSFT_FHIR_SQL_SA_PASSWORD} -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'"]
+      interval: 10s
+      timeout: 10s
+      retries: 6

--- a/container-support/compose/docker-compose.server.yml
+++ b/container-support/compose/docker-compose.server.yml
@@ -10,6 +10,8 @@ services:
       LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
       LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
       LFH_CONNECT_EXTERNAL_HOST_IP: "127.0.0.1"
+      LFH_CONNECT_FHIR-R4_EXTERNALSERVERS: "https://ibm-fhir:9443/fhir-server/api/v4"
+#      LFH_CONNECT_FHIR-R4_EXTERNALSERVERS: "https://fhiruser:change-password@ibm-fhir:9443/fhir-server/api/v4,http://msft-fhir:8080"
     depends_on:
       - "kafka"
       - "nats-server"


### PR DESCRIPTION
This PR adds an "integration" profile to the docker-compose stack to support LFH route development and integration testing with external systems. Systems supported within the integration profile include IBM and MSFT FHIR Servers.

Updates for Postman examples and integration tests will be submitted in a separate PR.

To test the profile
```
# start the integration profile
cd connect/container-support/compose
source start-stack.sh integration

# monitor the MSFT FHIR SQL DB and MSFT FHIR Servers to determine when they are running
# the MSFT FHIR Server will restart until the SQL DB is initialized
docker-compose ps 

# send a request to MSFT FHIR for it's capability statement
curl -X GET http://localhost:9090/metadata