### PR TITLE
Add Kong to Raspberry Pi docker-compose profile

### DIFF
--- a/container-support/compose/docker-compose.pi.yml
+++ b/container-support/compose/docker-compose.pi.yml
@@ -10,10 +10,10 @@ services:
     image: ${LFH_CONNECT_IMAGE}
     restart: "always"
     environment:
-      LFH_CONNECT_DATASTORE_URI: "{{lfh.connect.datastore.host}}:<topicName>?brokers=kafka:9092"
+      LFH_CONNECT_DATASTORE_URI: "kafka:<topicName>?brokers=kafka:9092"
       LFH_CONNECT_MESSAGING_URI: "nats:lfh-events?servers=nats-server:4222"
       LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS: "nats-server:4222"
-      LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:{{lfh.connect.orthanc_server.port}}/instances"
+      LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
       LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
       LFH_CONNECT_EXTERNAL_HOST_IP: "127.0.0.1"
     ports:

--- a/container-support/compose/docker-compose.pi.yml
+++ b/container-support/compose/docker-compose.pi.yml
@@ -16,9 +16,35 @@ services:
       LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
       LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
       LFH_CONNECT_EXTERNAL_HOST_IP: "127.0.0.1"
-    ports:
-      - ${LFH_CONNECT_MLLP_PORT}:${LFH_CONNECT_MLLP_PORT}
-      - ${LFH_CONNECT_HTTP_PORT}:${LFH_CONNECT_HTTP_PORT}
     depends_on:
       - "kafka"
       - "nats-server"
+  postgres:
+    image: ${LFH_PG_IMAGE}
+    restart: "always"
+    environment:
+      PGDATA: ${LFH_PG_DATA}
+      POSTGRES_USER: ${LFH_PG_USER}
+      POSTGRES_PASSWORD: ${LFH_PG_PASSWORD}
+      POSTGRES_DB: ${LFH_KONG_DATABASE}
+    volumes:
+      - pg_data:${LFH_PG_DATA}
+  kong:
+    image: ${LFH_KONG_IMAGE}
+    restart: always
+    depends_on:
+      - postgres
+    ports:
+      - ${LFH_KONG_SSL_PORT}:${LFH_KONG_SSL_PORT}
+      - ${LFH_KONG_ADMIN_SSL_PORT}:${LFH_KONG_ADMIN_SSL_PORT}
+      - ${LFH_KONG_MLLP_PORT}:${LFH_KONG_MLLP_PORT}
+    environment:
+      KONG_DATABASE: ${LFH_KONG_DATABASE_TYPE}
+      KONG_PG_HOST: postgres
+      KONG_PG_USER: ${LFH_PG_USER}
+      KONG_PG_PASSWORD: ${LFH_PG_PASSWORD}
+      KONG_ADMIN_LISTEN: ${LFH_KONG_ADMIN_LISTEN}
+      KONG_STREAM_LISTEN: ${LFH_KONG_STREAM_LISTEN}
+      KONG_LOG_LEVEL: ${LFH_KONG_LOG_LEVEL}
+volumes:
+  pg_data: { }

--- a/container-support/compose/start-stack.sh
+++ b/container-support/compose/start-stack.sh
@@ -54,6 +54,8 @@ case "${LFH_COMPOSE_PROFILE}" in
   ;;
   pi)
   echo "starting LFH compose pi profile"
+  export COMPOSE_FILE=docker-compose.yml:docker-compose.pi.yml:docker-compose.kong-migration.yml
+  . ./configure-kong.sh
   export COMPOSE_FILE=docker-compose.yml:docker-compose.pi.yml
   ;;
   *)

--- a/src/main/java/com/linuxforhealth/connect/builder/OrthancRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/OrthancRouteBuilder.java
@@ -7,15 +7,12 @@ package com.linuxforhealth.connect.builder;
 
 import com.linuxforhealth.connect.processor.LinuxForHealthMessage;
 import com.linuxforhealth.connect.processor.MetaDataProcessor;
-import com.linuxforhealth.connect.support.CamelContextSupport;
-import com.linuxforhealth.connect.support.LFHKafkaConsumer;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.List;
 import org.apache.camel.Exchange;
+import org.apache.camel.builder.SimpleBuilder;
 import org.apache.camel.component.kafka.KafkaConstants;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.json.JSONObject;
@@ -44,9 +41,6 @@ public class OrthancRouteBuilder extends BaseRouteBuilder {
 
     @Override
     protected void buildRoute(String routePropertyNamespace) {
-        CamelContextSupport contextSupport = new CamelContextSupport(getContext());
-        String orthancServerUri = contextSupport.getProperty("lfh.connect.orthanc_server.uri");
-        String orthancExternalUri = contextSupport.getProperty("lfh.connect.orthanc_server.external.uri");
 
        /**
         * Stores a DICOM image in Orthanc, converts it to .png and gets patient info for the image.
@@ -69,9 +63,16 @@ public class OrthancRouteBuilder extends BaseRouteBuilder {
         .marshal().mimeMultipart()
         .removeHeaders("Camel*")
         .removeHeaders("Host")
-        .to(orthancServerUri)
+        .to("{{lfh.connect.orthanc.server.uri}}")
         .id(ORTHANC_PRODUCER_POST_ID)
         .process(exchange -> {
+            String orthancExternalUri = SimpleBuilder
+                .simple("${properties:lfh.connect.orthanc.server.external.uri}")
+                .evaluate(exchange, String.class);
+            String orthancServerUri = SimpleBuilder
+                .simple("${properties:lfh.connect.orthanc.server.uri}")
+                .evaluate(exchange, String.class);
+
             // Get the resulting image id & create uri for downstream image retrieval
             String body = exchange.getIn().getBody(String.class);
             JSONObject obj = new JSONObject(body);
@@ -88,6 +89,10 @@ public class OrthancRouteBuilder extends BaseRouteBuilder {
         .toD("${exchangeProperty[location]}")
         .id(ORTHANC_PRODUCER_GET_IMAGE_ID)
         .process(exchange -> {
+            String orthancServerUri = SimpleBuilder
+                .simple("${properties:lfh.connect.orthanc.server.uri}")
+                .evaluate(exchange, String.class);
+
             // Get the resulting image bytes
             byte[] body = exchange.getIn().getBody(byte[].class);
             exchange.setProperty("imageBody", Base64.getEncoder().encodeToString(body));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,8 +51,8 @@ lfh.connect.bluebutton-20.cms.clientsecret=ENC(LVddmNBkdgHTPxewJsd/ji9i36omfi9o+
 lfh.connect.orthanc.uri=jetty:http://{{lfh.connect.host}}:{{lfh.connect.http.port}}/orthanc/instances?httpMethodRestrict=POST&enableMultipartFilter=true
 lfh.connect.orthanc.dataformat=dicom
 lfh.connect.orthanc.messagetype=Image
-lfh.connect.orthanc_server.uri=http://localhost:8042/instances
-lfh.connect.orthanc_server.external.uri=http://{{lfh.connect.external.host.ip}}:8042/instances
+lfh.connect.orthanc.server.uri=http://localhost:8042/instances
+lfh.connect.orthanc.server.external.uri=http://{{lfh.connect.external.host.ip}}:8042/instances
 lfh.connect.orthanc.image.uri=jetty:http://{{lfh.connect.host}}:{{lfh.connect.http.port}}/orthanc/images?httpMethodRestrict=GET
 
 # X12


### PR DESCRIPTION
- Modified Orthanc route to use SimpleBuilder to retrieve properties
- Modified an Orthanc property name to remove '_'
- Updated Raspberry Pi yml to add kong and postgres