### PR TITLE
Added ability to use existing postgres volume

### DIFF
--- a/container-support/compose/configure-kong.sh
+++ b/container-support/compose/configure-kong.sh
@@ -21,8 +21,7 @@ DB_CONFIG_CONFIGURED_MESSAGE="Database already bootstrapped"
 KONG_SERVICE="kong"
 KONG_SERVICE_MESSAGE="finished preloading 'plugins' into the core_cache"
 
-# curl flags
-FLAGS="--insecure --silent --output /dev/null"
+CURL_FLAGS="--insecure --silent --output /dev/null"
 
 function is_ready() {
     local service_name=$1
@@ -74,7 +73,7 @@ function add_http_route() {
   local service=$4
   local admin_url="https://localhost:8444/services/${service}/routes"
 
-  curl $FLAGS "${admin_url}" \
+  curl $CURL_FLAGS "${admin_url}" \
   -H 'Content-Type: application/json' \
   -d '{"paths": ["'"${url}"'"], "methods": ["'"${method}"'"], "name": "'"${name}"'", "protocols": ["https"], "strip_path": false}'
 }
@@ -101,7 +100,7 @@ lfhmllp=${LFH_CONNECT_MLLP_PORT}
 kongmllp=${LFH_KONG_MLLP_PORT}
 
 echo "Adding a kong service for all LinuxForHealth http routes"
-curl $FLAGS https://localhost:8444/services \
+curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-http-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
 
@@ -114,17 +113,17 @@ add_http_route "x12-post-route" "POST" "/x12" "lfh-http-service"
 add_http_route "ccd-post-route" "POST" "/ccd" "lfh-http-service"
 
 echo "Adding a kong service for the LinuxForHealth hl7v2 mllp route"
-curl $FLAGS https://localhost:8444/services \
+curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-hl7v2-service", "url": "tcp://'"${host}"':'"${lfhmllp}"'"}'
 
 echo "Adding a kong route that matches incoming requests and sends them to the lfh-hl7v2-service url"
-curl $FLAGS https://localhost:8444/services/lfh-hl7v2-service/routes \
+curl $CURL_FLAGS https://localhost:8444/services/lfh-hl7v2-service/routes \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-hl7v2-route", "protocols": ["tcp", "tls"], "destinations": [{"port":'"${kongmllp}"'}]}'
 
 echo "Adding a kong service for the LinuxForHealth Blue Button 2.0 routes"
-curl $FLAGS https://localhost:8444/services \
+curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-bluebutton-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
 

--- a/container-support/oci/configure-kong.sh
+++ b/container-support/oci/configure-kong.sh
@@ -12,6 +12,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# curl flags
+FLAGS="--insecure --silent --output /dev/null"
+
 function add_http_route() {
   local name=$1
   local method=$2
@@ -19,10 +22,9 @@ function add_http_route() {
   local service=$4
   local admin_url="https://localhost:8444/services/${service}/routes"
 
-  curl --insecure "${admin_url}" \
+  curl $FLAGS "${admin_url}" \
   -H 'Content-Type: application/json' \
   -d '{"paths": ["'"${url}"'"], "methods": ["'"${method}"'"], "name": "'"${name}"'", "protocols": ["https"], "strip_path": false}'
-  echo ""
 }
 
 host=${LFH_CONNECT_SERVICE_NAME}
@@ -31,10 +33,9 @@ lfhmllp=${LFH_CONNECT_MLLP_PORT}
 kongmllp=${LFH_KONG_MLLP_PORT}
 
 echo "Adding a kong service for LinuxForHealth http routes"
-curl --insecure https://localhost:8444/services \
+curl $FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-http-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
-echo ""
 
 echo "Adding kong http routes that match incoming requests and send them to the lfh-http-service url"
 add_http_route "hello-world-route" "GET" "/hello-world" "lfh-http-service"
@@ -45,22 +46,19 @@ add_http_route "x12-post-route" "POST" "/x12" "lfh-http-service"
 add_http_route "ccd-post-route" "POST" "/ccd" "lfh-http-service"
 
 echo "Adding a kong service for the LinuxForHealth hl7v2 mllp route"
-curl --insecure https://localhost:8444/services \
+curl $FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-hl7v2-service", "url": "tcp://'"${host}"':'"${lfhmllp}"'"}'
-echo ""
 
 echo "Adding a kong route that matches incoming requests and sends them to the lfh-hl7v2-service url"
-curl --insecure https://localhost:8444/services/lfh-hl7v2-service/routes \
+curl $FLAGS https://localhost:8444/services/lfh-hl7v2-service/routes \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-hl7v2-route", "protocols": ["tcp", "tls"], "destinations": [{"port":'"${kongmllp}"'}]}'
-echo ""
 
 echo "Adding a kong service for the LinuxForHealth Blue Button 2.0 routes"
-curl --insecure https://localhost:8444/services \
+curl $FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-bluebutton-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
-echo ""
 
 echo "Adding Kong http routes that match incoming requests and send them to the lfh-bluebutton-service url"
 add_http_route "bb-authorize-route" "GET" "/bluebutton/authorize" "lfh-bluebutton-service"

--- a/container-support/oci/configure-kong.sh
+++ b/container-support/oci/configure-kong.sh
@@ -12,8 +12,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# curl flags
-FLAGS="--insecure --silent --output /dev/null"
+CURL_FLAGS="--insecure --silent --output /dev/null"
 
 function add_http_route() {
   local name=$1
@@ -22,7 +21,7 @@ function add_http_route() {
   local service=$4
   local admin_url="https://localhost:8444/services/${service}/routes"
 
-  curl $FLAGS "${admin_url}" \
+  curl $CURL_FLAGS "${admin_url}" \
   -H 'Content-Type: application/json' \
   -d '{"paths": ["'"${url}"'"], "methods": ["'"${method}"'"], "name": "'"${name}"'", "protocols": ["https"], "strip_path": false}'
 }
@@ -33,7 +32,7 @@ lfhmllp=${LFH_CONNECT_MLLP_PORT}
 kongmllp=${LFH_KONG_MLLP_PORT}
 
 echo "Adding a kong service for LinuxForHealth http routes"
-curl $FLAGS https://localhost:8444/services \
+curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-http-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
 
@@ -46,17 +45,17 @@ add_http_route "x12-post-route" "POST" "/x12" "lfh-http-service"
 add_http_route "ccd-post-route" "POST" "/ccd" "lfh-http-service"
 
 echo "Adding a kong service for the LinuxForHealth hl7v2 mllp route"
-curl $FLAGS https://localhost:8444/services \
+curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-hl7v2-service", "url": "tcp://'"${host}"':'"${lfhmllp}"'"}'
 
 echo "Adding a kong route that matches incoming requests and sends them to the lfh-hl7v2-service url"
-curl $FLAGS https://localhost:8444/services/lfh-hl7v2-service/routes \
+curl $CURL_FLAGS https://localhost:8444/services/lfh-hl7v2-service/routes \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-hl7v2-route", "protocols": ["tcp", "tls"], "destinations": [{"port":'"${kongmllp}"'}]}'
 
 echo "Adding a kong service for the LinuxForHealth Blue Button 2.0 routes"
-curl $FLAGS https://localhost:8444/services \
+curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
   -d '{"name": "lfh-bluebutton-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
 

--- a/container-support/oci/lfh-oci-services.sh
+++ b/container-support/oci/lfh-oci-services.sh
@@ -200,7 +200,8 @@ function start() {
                 --env KONG_PG_PASSWORD="${LFH_PG_PASSWORD}" \
                 "${LFH_KONG_IMAGE}" \
                 kong migrations bootstrap -v
-  wait_for_log_msg ${LFH_KONG_MIGRATION_SERVICE_NAME} "Database is up-to-date"
+  { wait_for_log_msg ${LFH_KONG_MIGRATION_SERVICE_NAME} "Database is up-to-date"; } || \
+  { wait_for_log_msg ${LFH_KONG_MIGRATION_SERVICE_NAME} "Database already bootstrapped"; }
 
   echo "launch kong"
   ${OCI_COMMAND} pull "${LFH_KONG_IMAGE}"
@@ -237,6 +238,8 @@ function remove() {
   ${OCI_COMMAND} rm -f ${LFH_PG_SERVICE_NAME}
   ${OCI_COMMAND} rm -f ${LFH_KONG_SERVICE_NAME}
   ${OCI_COMMAND} rm -f ${LFH_KONG_MIGRATION_SERVICE_NAME}
+
+  ${OCI_COMMAND} volume rm pg_data
 
   ${OCI_COMMAND} network rm ${LFH_NETWORK_NAME}
 }


### PR DESCRIPTION
If a postgres volume exists, use it.
- Added extra check for kong-migration log statement in case of existing postgres volume
- Cleaned up kong curl output