### PR TITLE
Remove potential phi logging in kafka to nlp service routes

### DIFF
--- a/src/main/java/com/linuxforhealth/connect/builder/KafkaFhirToTextRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/KafkaFhirToTextRouteBuilder.java
@@ -1,17 +1,13 @@
 package com.linuxforhealth.connect.builder;
 
 import com.linuxforhealth.connect.support.FhirAttachmentText;
-import org.apache.camel.LoggingLevel;
 import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.RouteBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.MediaType;
 
 public class KafkaFhirToTextRouteBuilder extends RouteBuilder {
 
-    private final Logger logger = LoggerFactory.getLogger(KafkaFhirToTextRouteBuilder.class);
     @PropertyInject("lfh.connect.nlp.enable")
     private static boolean enableRoute;
     public final static String PROP_RESOURCE_TYPE = "resourceType";
@@ -44,7 +40,6 @@ public class KafkaFhirToTextRouteBuilder extends RouteBuilder {
         from("kafka:{{lfh.connect.nlp.fhir-topics}}?brokers={{lfh.connect.datastore.brokers}}")
             .routeId(ROUTE_ID)
             .autoStartup(enableRoute) // property-based route enablement toggle
-            .log(LoggingLevel.DEBUG, logger, "[kafka-input]:\n ${body}")
             .to(ROUTE_URI_FHIR_LFH_MSG)
             ;
 
@@ -91,7 +86,6 @@ public class KafkaFhirToTextRouteBuilder extends RouteBuilder {
         //
         from(ROUTE_URI_FHIR_RESOURCE)
             .routeId(ROUTE_ID_GET_FHIR)
-            .log(LoggingLevel.DEBUG, logger, "[fhir-resource] INPUT:\n${body}")
 
             // Send to div narrative and attachment process in parallel
             .multicast()
@@ -117,7 +111,6 @@ public class KafkaFhirToTextRouteBuilder extends RouteBuilder {
                 .to("tika:parse?tikaParseOutputFormat=text")
             .end()
 
-            .log(LoggingLevel.DEBUG, logger, "${body}")
             .to(NlpRouteBuilder.NLP_ROUTE_URI)
             ;
 
@@ -130,7 +123,6 @@ public class KafkaFhirToTextRouteBuilder extends RouteBuilder {
         from(ROUTE_URI_FHIR_TEXT_DIV)
             .routeId(ROUTE_ID_FHIR_TEXT_DIV)
             .convertBodyTo(String.class)
-            .log(LoggingLevel.DEBUG, logger, "[text-div] INPUT:\n${body}")
             .setProperty("resourceTypeElement", constant("narrative"))
 
             .choice()

--- a/src/main/java/com/linuxforhealth/connect/builder/NlpRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/NlpRouteBuilder.java
@@ -45,7 +45,6 @@ public class NlpRouteBuilder extends BaseRouteBuilder {
         from(NLP_ROUTE_URI)
             .routeId(NLP_ROUTE_ID)
             .autoStartup(enableRoute)
-            .log(LoggingLevel.DEBUG, logger, "Received: ${body}")
             .setHeader(Exchange.HTTP_METHOD, constant(HttpMethod.POST))
             .setHeader(Exchange.CONTENT_TYPE, constant(ContentType.TEXT_PLAIN))
             .convertBodyTo(String.class)
@@ -54,7 +53,7 @@ public class NlpRouteBuilder extends BaseRouteBuilder {
             .process(new Processor() {
                 @Override
                 public void process(Exchange exchange) throws Exception {
-                    logger.debug("wrap request text in json: " + !"".equalsIgnoreCase(requestJson));
+
                     if (!"".equalsIgnoreCase(requestJson)) {
                         exchange.getIn().setHeader(Exchange.CONTENT_TYPE, ContentType.APPLICATION_JSON);
                         String json = new ObjectMapper().writeValueAsString(exchange.getIn().getBody(String.class));
@@ -73,7 +72,6 @@ public class NlpRouteBuilder extends BaseRouteBuilder {
             .to("{{lfh.connect.nlp.uri}}{{lfh.connect.nlp.auth}}")
             .log(LoggingLevel.DEBUG, logger, "NLP response code: ${header.CamelHttpResponseCode}")
             .unmarshal().json()
-            .log(LoggingLevel.DEBUG, logger, "NLP response body: ${body}")
 
             .choice()
 
@@ -84,7 +82,7 @@ public class NlpRouteBuilder extends BaseRouteBuilder {
                 .endChoice()
 
                 .otherwise()
-                    .log(LoggingLevel.ERROR, logger, "NLP Service error response code: ${header.CamelHttpResponseCode}, response body ${body}")
+                    .log(LoggingLevel.ERROR, logger, "NLP Service error response code: ${header.CamelHttpResponseCode}")
                     .stop()
                 .endChoice()
 


### PR DESCRIPTION
Addendum PR to address issue #201 

Scrubbed the log statements within routes consuming fhir resources from a stream and routing the text to an nlp service to preclude logging phi data.