### PR TITLE
Add ETL Route to Kong Configuration

### DIFF
--- a/container-support/compose/configure-kong.sh
+++ b/container-support/compose/configure-kong.sh
@@ -111,6 +111,7 @@ add_http_route "orthanc-image-post-route" "POST" "/orthanc/instances" "lfh-http-
 add_http_route "kafka-get-message-route" "GET" "/datastore/message" "lfh-http-service"
 add_http_route "x12-post-route" "POST" "/x12" "lfh-http-service"
 add_http_route "ccd-post-route" "POST" "/ccd" "lfh-http-service"
+add_http_route "etl-route" "POST" "/etl" "lfh-http-service"
 
 echo "Adding a kong service for the LinuxForHealth hl7v2 mllp route"
 curl $CURL_FLAGS https://localhost:8444/services \


### PR DESCRIPTION
This PR adds the ETL route to the Kong Configuration to ensure that https/tls is supported.

Tested with
```
https://127.0.0.1:8443/etl/
```