### PR TITLE
New Property for NATS SSL Support

### DIFF
--- a/src/main/java/com/linuxforhealth/connect/support/LFHServiceManager.java
+++ b/src/main/java/com/linuxforhealth/connect/support/LFHServiceManager.java
@@ -46,6 +46,7 @@ public class LFHServiceManager {
         String truststorePwd = properties.getProperty("lfh.connect.ssl.truststore.password");
         String keystore = properties.getProperty("lfh.connect.ssl.keystore.filename");
         String keystorePwd = properties.getProperty("lfh.connect.ssl.keystore.password");
+        boolean isNATSSSLEnabled = properties.getProperty("lfh.connect.messaging.nats.ssl", "true").equalsIgnoreCase("true");
         long kafkaConsumerTimeout = Long.parseLong(properties.getProperty("lfh.connect.datastore.get.timeout.milliseconds"));
         producer = new LFHKafkaProducer();
         consumer = new LFHKafkaConsumer();
@@ -67,7 +68,7 @@ public class LFHServiceManager {
             producer.start(brokers);
             for (String host: hosts) {
                 NATSSubscriber subscriber = new NATSSubscriber(host, subject,
-                    createOptions(host, true, true), producer, properties);
+                    createOptions(host, true, isNATSSSLEnabled), producer, properties);
                 new Thread(subscriber).start();
             }
         } catch (Exception ex) {


### PR DESCRIPTION
This PR adds a new property, lfh.connect.messaging.nats.ssl, to the application to support enabling and disabling tls connections to NATS. TLS connections are enabled by default and can be set explicitly by setting the property to "true" (case insensitive).  Setting the property to any other value will disable the TLS connections from LFH to NATs.

I'm adding this in to support a project/pov that is executing within a secure enclave/environment. This setting allows us to get a baseline installation in place, prior to securing the environment. 

I tested this change with the following compose configuration
```yaml
version: "3.7"
services:
  nats-server:
    image: docker.io/linuxforhealth/jetstream:v0.0.19
    restart: "always"
    expose:
      - "4222"
    command: server

  zookeeper:
    image: docker.io/linuxforhealth/zookeeper-alpine:3.6.2
    expose:
      - "2181"

  kafka:
    image: docker.io/linuxforhealth/kafka-alpine:2.5.0
    restart: "always"
    expose:
      - "9092"
      - "9094"
    environment:
      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
      KAFKA_LISTENERS: "INTERNAL://kafka:9092"
      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092"
      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT"
      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
    depends_on:
      - "zookeeper"

  lfh:
    image: docker.io/linuxforhealth/connect-alpine:tdw-dev
    restart: "always"
    environment:
      LFH_CONNECT_MESSAGING_NATS_SSL: "False"
      LFH_CONNECT_DATASTORE_URI: "kafka:<topicName>?brokers=kafka:9092"
      LFH_CONNECT_MESSAGING_RESPONSE_URI: "nats:EVENTS.responses?servers=nats-server:4222"
      LFH_CONNECT_MESSAGING_ERROR_URI: "nats:EVENTS.errors?servers=nats-server:4222"
      LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS: "nats-server:4222"
      LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
      LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
      LFH_CONNECT_EXTERNAL_HOST_IP: "127.0.0.1"
    ports:
      - "8080:8080"
      - "2575:2575"
    depends_on:
      - "kafka"
      - "nats-server"
```     