### PR TITLE
Use relative paths in LFH result messages

### DIFF
--- a/container-support/compose/configure-kong.sh
+++ b/container-support/compose/configure-kong.sh
@@ -66,18 +66,6 @@ function wait_for_cmd() {
     return 1
 }
 
-function add_http_route() {
-  local name=$1
-  local method=$2
-  local url=$3
-  local service=$4
-  local admin_url="https://localhost:8444/services/${service}/routes"
-
-  curl $CURL_FLAGS "${admin_url}" \
-  -H 'Content-Type: application/json' \
-  -d '{"paths": ["'"${url}"'"], "methods": ["'"${method}"'"], "name": "'"${name}"'", "protocols": ["https"], "strip_path": false}'
-}
-
 # wait for postgres
 docker-compose up -d "$DB_SERVICE"
 is_ready "$DB_SERVICE" "$DB_SERVICE_MESSAGE"
@@ -93,46 +81,4 @@ docker-compose up -d "$KONG_SERVICE"
 is_ready "$KONG_SERVICE" "$KONG_SERVICE_MESSAGE"
 wait_for_cmd curl --silent --insecure https://localhost:8444/services
 
-# host is how kong needs to reference LFH, depending on where LFH is running
-host=${LFH_KONG_LFHHOST}
-lfhhttp=${LFH_CONNECT_HTTP_PORT}
-lfhmllp=${LFH_CONNECT_MLLP_PORT}
-kongmllp=${LFH_KONG_MLLP_PORT}
-
-echo "Adding a kong service for all LinuxForHealth http routes"
-curl $CURL_FLAGS https://localhost:8444/services \
-  -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-http-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
-
-echo "Adding kong http routes that match incoming requests and send them to the lfh-http-service url"
-add_http_route "hello-world-route" "GET" "/hello-world" "lfh-http-service"
-add_http_route "fhir-r4-patient-post-route" "POST" "/fhir/r4/Patient" "lfh-http-service"
-add_http_route "orthanc-image-post-route" "POST" "/orthanc/instances" "lfh-http-service"
-add_http_route "kafka-get-message-route" "GET" "/datastore/message" "lfh-http-service"
-add_http_route "x12-post-route" "POST" "/x12" "lfh-http-service"
-add_http_route "ccd-post-route" "POST" "/ccd" "lfh-http-service"
-add_http_route "etl-route" "POST" "/etl" "lfh-http-service"
-
-echo "Adding a kong service for the LinuxForHealth hl7v2 mllp route"
-curl $CURL_FLAGS https://localhost:8444/services \
-  -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-hl7v2-service", "url": "tcp://'"${host}"':'"${lfhmllp}"'"}'
-
-echo "Adding a kong route that matches incoming requests and sends them to the lfh-hl7v2-service url"
-curl $CURL_FLAGS https://localhost:8444/services/lfh-hl7v2-service/routes \
-  -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-hl7v2-route", "protocols": ["tcp", "tls"], "destinations": [{"port":'"${kongmllp}"'}]}'
-
-echo "Adding a kong service for the LinuxForHealth Blue Button 2.0 routes"
-curl $CURL_FLAGS https://localhost:8444/services \
-  -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-bluebutton-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
-
-echo "Adding Kong http routes that match incoming requests and send them to the lfh-bluebutton-service url"
-add_http_route "bb-authorize-route" "GET" "/bluebutton/authorize" "lfh-bluebutton-service"
-add_http_route "bb-handler-route" "GET" "/bluebutton/handler" "lfh-bluebutton-service"
-add_http_route "bb-patient-route" "GET" "/bluebutton/v1/Patient" "lfh-bluebutton-service"
-add_http_route "bb-eob-route" "GET" "/bluebutton/v1/ExplanationOfBenefit" "lfh-bluebutton-service"
-add_http_route "bb-coverage-route" "GET" "/bluebutton/v1/Coverage" "lfh-bluebutton-service"
-
-echo "Kong configuration complete"
+. ../oci/configure-kong.sh

--- a/container-support/compose/docker-compose.pi.yml
+++ b/container-support/compose/docker-compose.pi.yml
@@ -20,7 +20,6 @@ services:
       LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS: "nats-server:4222"
       LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
       LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
-      LFH_CONNECT_EXTERNAL_HOST_IP: "127.0.0.1"
     depends_on:
       - "kafka"
       - "nats-server"

--- a/container-support/compose/docker-compose.server.yml
+++ b/container-support/compose/docker-compose.server.yml
@@ -12,7 +12,6 @@ services:
       LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS: "nats-server:4222"
       LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
       LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
-      LFH_CONNECT_EXTERNAL_HOST_IP: "127.0.0.1"
     depends_on:
       - "kafka"
       - "nats-server"

--- a/container-support/compose/start-stack.sh
+++ b/container-support/compose/start-stack.sh
@@ -30,13 +30,15 @@ echo "LFH compose profile is set to ${LFH_COMPOSE_PROFILE}"
 # configures the LFH Kong API Gateway for the dev, integration, and server profiles
 case "${LFH_COMPOSE_PROFILE}" in
   dev)
-    export LFH_KONG_LFHHOST="localhost"
-    [ "$(uname -s)" == "Darwin" ] && export LFH_KONG_LFHHOST="host.docker.internal"
+    export LFH_KONG_CONNECT_HOST="localhost"
+    [ "$(uname -s)" == "Darwin" ] && export LFH_KONG_CONNECT_HOST="host.docker.internal"
+    export LFH_KONG_ORTHANC_HOST=${LFH_KONG_CONNECT_HOST}
     export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:docker-compose.kong-migration.yml
     source ./configure-kong.sh
     ;;
   integration|pi|server)
-    export LFH_KONG_LFHHOST="compose_lfh_1"
+    export LFH_KONG_CONNECT_HOST="compose_lfh_1"
+    export LFH_KONG_ORTHANC_HOST="compose_orthanc_1"
     export COMPOSE_FILE=docker-compose.yml:docker-compose.server.yml:docker-compose.kong-migration.yml
     source ./configure-kong.sh
     ;;

--- a/container-support/oci/configure-kong.sh
+++ b/container-support/oci/configure-kong.sh
@@ -26,15 +26,13 @@ function add_http_route() {
   -d '{"paths": ["'"${url}"'"], "methods": ["'"${method}"'"], "name": "'"${name}"'", "protocols": ["https"], "strip_path": false}'
 }
 
-host=${LFH_CONNECT_SERVICE_NAME}
-lfhhttp=${LFH_CONNECT_HTTP_PORT}
-lfhmllp=${LFH_CONNECT_MLLP_PORT}
-kongmllp=${LFH_KONG_MLLP_PORT}
+if [ -z ${LFH_KONG_CONNECT_HOST} ]; then connect_host=${LFH_CONNECT_SERVICE_NAME}; else connect_host=${LFH_KONG_CONNECT_HOST}; fi
+if [ -z ${LFH_KONG_ORTHANC_HOST} ]; then connect_host=${LFH_ORTHANC_SERVICE_NAME}; else connect_host=${LFH_KONG_ORTHANC_HOST}; fi
 
-echo "Adding a kong service for LinuxForHealth http routes"
+echo "Adding a kong service for all LinuxForHealth http routes"
 curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-http-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
+  -d '{"name": "lfh-http-service", "url": "http://'"${connect_host}"':'"${LFH_CONNECT_HTTP_PORT}"'"}'
 
 echo "Adding kong http routes that match incoming requests and send them to the lfh-http-service url"
 add_http_route "hello-world-route" "GET" "/hello-world" "lfh-http-service"
@@ -43,21 +41,22 @@ add_http_route "orthanc-image-post-route" "POST" "/orthanc/instances" "lfh-http-
 add_http_route "kafka-get-message-route" "GET" "/datastore/message" "lfh-http-service"
 add_http_route "x12-post-route" "POST" "/x12" "lfh-http-service"
 add_http_route "ccd-post-route" "POST" "/ccd" "lfh-http-service"
+add_http_route "etl-route" "POST" "/etl" "lfh-http-service"
 
 echo "Adding a kong service for the LinuxForHealth hl7v2 mllp route"
 curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-hl7v2-service", "url": "tcp://'"${host}"':'"${lfhmllp}"'"}'
+  -d '{"name": "lfh-hl7v2-service", "url": "tcp://'"${connect_host}"':'"${LFH_CONNECT_MLLP_PORT}"'"}'
 
 echo "Adding a kong route that matches incoming requests and sends them to the lfh-hl7v2-service url"
 curl $CURL_FLAGS https://localhost:8444/services/lfh-hl7v2-service/routes \
   -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-hl7v2-route", "protocols": ["tcp", "tls"], "destinations": [{"port":'"${kongmllp}"'}]}'
+  -d '{"name": "lfh-hl7v2-route", "protocols": ["tcp", "tls"], "destinations": [{"port":'"${LFH_KONG_MLLP_PORT}"'}]}'
 
 echo "Adding a kong service for the LinuxForHealth Blue Button 2.0 routes"
 curl $CURL_FLAGS https://localhost:8444/services \
   -H 'Content-Type: application/json' \
-  -d '{"name": "lfh-bluebutton-service", "url": "http://'"${host}"':'"${lfhhttp}"'"}'
+  -d '{"name": "lfh-bluebutton-service", "url": "http://'"${connect_host}"':'"${LFH_CONNECT_HTTP_PORT}"'"}'
 
 echo "Adding Kong http routes that match incoming requests and send them to the lfh-bluebutton-service url"
 add_http_route "bb-authorize-route" "GET" "/bluebutton/authorize" "lfh-bluebutton-service"
@@ -65,3 +64,13 @@ add_http_route "bb-handler-route" "GET" "/bluebutton/handler" "lfh-bluebutton-se
 add_http_route "bb-patient-route" "GET" "/bluebutton/v1/Patient" "lfh-bluebutton-service"
 add_http_route "bb-eob-route" "GET" "/bluebutton/v1/ExplanationOfBenefit" "lfh-bluebutton-service"
 add_http_route "bb-coverage-route" "GET" "/bluebutton/v1/Coverage" "lfh-bluebutton-service"
+
+echo "Adding a kong service for LinuxForHealth Orthanc direct routes"
+curl $CURL_FLAGS https://localhost:8444/services \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "lfh-orthanc-service", "url": "http://'"${orthanc_host}"':'"${LFH_ORTHANC_HTTP_PORT}"'"}'
+
+echo "Adding an Orthanc http route that matches incoming requests and sends them to the lfh-orthanc-service url"
+add_http_route "orthanc-route" "GET" "/instances" "lfh-orthanc-service"
+
+echo "Kong configuration complete"

--- a/container-support/oci/configure-kong.sh
+++ b/container-support/oci/configure-kong.sh
@@ -27,7 +27,7 @@ function add_http_route() {
 }
 
 if [ -z ${LFH_KONG_CONNECT_HOST} ]; then connect_host=${LFH_CONNECT_SERVICE_NAME}; else connect_host=${LFH_KONG_CONNECT_HOST}; fi
-if [ -z ${LFH_KONG_ORTHANC_HOST} ]; then connect_host=${LFH_ORTHANC_SERVICE_NAME}; else connect_host=${LFH_KONG_ORTHANC_HOST}; fi
+if [ -z ${LFH_KONG_ORTHANC_HOST} ]; then orthanc_host=${LFH_ORTHANC_SERVICE_NAME}; else orthanc_host=${LFH_KONG_ORTHANC_HOST}; fi
 
 echo "Adding a kong service for all LinuxForHealth http routes"
 curl $CURL_FLAGS https://localhost:8444/services \

--- a/container-support/oci/configure-kong.sh
+++ b/container-support/oci/configure-kong.sh
@@ -26,8 +26,8 @@ function add_http_route() {
   -d '{"paths": ["'"${url}"'"], "methods": ["'"${method}"'"], "name": "'"${name}"'", "protocols": ["https"], "strip_path": false}'
 }
 
-if [ -z ${LFH_KONG_CONNECT_HOST} ]; then connect_host=${LFH_CONNECT_SERVICE_NAME}; else connect_host=${LFH_KONG_CONNECT_HOST}; fi
-if [ -z ${LFH_KONG_ORTHANC_HOST} ]; then orthanc_host=${LFH_ORTHANC_SERVICE_NAME}; else orthanc_host=${LFH_KONG_ORTHANC_HOST}; fi
+connect_host=${LFH_KONG_CONNECT_HOST:-${LFH_CONNECT_SERVICE_NAME}}
+orthanc_host=${LFH_KONG_ORTHANC_HOST:-${LFH_ORTHANC_SERVICE_NAME}}
 
 echo "Adding a kong service for all LinuxForHealth http routes"
 curl $CURL_FLAGS https://localhost:8444/services \

--- a/src/main/java/com/linuxforhealth/connect/builder/OrthancRouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/OrthancRouteBuilder.java
@@ -66,9 +66,6 @@ public class OrthancRouteBuilder extends BaseRouteBuilder {
         .to("{{lfh.connect.orthanc.server.uri}}")
         .id(ORTHANC_PRODUCER_POST_ID)
         .process(exchange -> {
-            String orthancExternalUri = SimpleBuilder
-                .simple("${properties:lfh.connect.orthanc.server.external.uri}")
-                .evaluate(exchange, String.class);
             String orthancServerUri = SimpleBuilder
                 .simple("${properties:lfh.connect.orthanc.server.uri}")
                 .evaluate(exchange, String.class);
@@ -78,7 +75,7 @@ public class OrthancRouteBuilder extends BaseRouteBuilder {
             JSONObject obj = new JSONObject(body);
             String id = obj.getString("ID");
             exchange.setProperty("imageId", id);
-            exchange.setProperty("dataUri", orthancExternalUri+"/"+id+"/preview");
+            exchange.setProperty("dataUri", "/instances/"+id+"/preview");
 
             // Set up for next call to get the .png image
             exchange.setProperty("location", orthancServerUri+"/"+id+"/preview");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
-# Connect ip, host and ports
-lfh.connect.external.host.ip=127.0.0.1
+# Connect host and ports
 lfh.connect.host=0.0.0.0
 lfh.connect.http.port=8080
 lfh.connect.mllp.port=2576
+lfh.orthanc.port=8042
 
 # HL7 V2 MLLP
 lfh.connect.bean.hl7encoder=org.apache.camel.component.hl7.HL7MLLPNettyEncoderFactory
@@ -52,8 +52,7 @@ lfh.connect.bluebutton-20.cms.clientsecret=ENC(LVddmNBkdgHTPxewJsd/ji9i36omfi9o+
 lfh.connect.orthanc.uri=jetty:http://{{lfh.connect.host}}:{{lfh.connect.http.port}}/orthanc/instances?httpMethodRestrict=POST&enableMultipartFilter=true
 lfh.connect.orthanc.dataformat=dicom
 lfh.connect.orthanc.messagetype=Image
-lfh.connect.orthanc.server.uri=http://localhost:8042/instances
-lfh.connect.orthanc.server.external.uri=http://{{lfh.connect.external.host.ip}}:8042/instances
+lfh.connect.orthanc.server.uri=http://localhost:{{lfh.orthanc.port}}/instances
 lfh.connect.orthanc.image.uri=jetty:http://{{lfh.connect.host}}:{{lfh.connect.http.port}}/orthanc/images?httpMethodRestrict=GET
 
 # X12

--- a/src/test/resources/messages/orthanc/result.json
+++ b/src/test/resources/messages/orthanc/result.json
@@ -1,1 +1,1 @@
-{"patientName":"Anonymized","image":"bW9jay1pbWFnZS1ieXRlcw==","patientId":"0","sourceType":"orthanc","sourceUri":"http://127.0.0.1:8042/instances/de11d211-6fcb8f9e-509b1519-5acd5d8e-7d127482/preview"}
+{"patientName":"Anonymized","image":"bW9jay1pbWFnZS1ieXRlcw==","patientId":"0","sourceType":"orthanc","sourceUri":"/instances/de11d211-6fcb8f9e-509b1519-5acd5d8e-7d127482/preview"}


### PR DESCRIPTION
This PR contains a number of changes:

1. Updated the data field of the result of a POST to the Orthanc server to include the relative location of the image as stored in Orthanc, e.g.:  instances/de11d211-6fcb8f9e-509b1519-5acd5d8e-7d127482/preview

2. Added an `/instances` Orthanc service route to Kong that goes directly to Orthanc (the first non-connect API in Kong). This allows a REST call to Kong to retrieve original image information stored in Orthanc (with the Orthanc username and password for basic auth).

3. Consolidated the configure-kong.sh script under container-support/oci.  The compose/configure-kong.sh sources ../oci/configure-kong.sh.

4. Removed all references to external host ip. e.g. LFH_CONNECT_EXTERNAL_HOST_IP: "127.0.0.1" because all relative urls can now be evaluated against kong.

Tested with dev and server compose profiles on amd64 and oci script on s390x.
