### PR TITLE
Property 'http://javax.xml.XMLConstants/property/accessExternalDTD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ application {
 }
 
 configurations {
+    // excluding xerces transitive dependency which causes conflict with JDK/JRE
+    // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8016153
+    // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8015487
     runtime.exclude group: 'xerces', module: 'xercesImpl'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ application {
     mainClassName = 'com.linuxforhealth.connect.App'
 }
 
+configurations {
+    runtime.exclude group: 'xerces', module: 'xercesImpl'
+}
+
 dependencies {
     // camel libraries
     implementation group: 'org.apache.camel', name: 'camel-core', version: project.camelVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ commonsLang3Version=3.10
 commonsDbcp2Version=2.7.0
 
 # framework verions
-camelVersion=3.4.0
+camelVersion=3.7.1
 jacksonVersion=2.11.0
 junitVersion=5.6.2
 


### PR DESCRIPTION
This PR resolves an issue where an Apache Tika transitive dependency, xerces, generates the following stack trace and warning

```java
org.xml.sax.SAXNotRecognizedException: Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not recognized.
        at org.apache.xerces.jaxp.validation.XMLSchemaFactory.setProperty(Unknown Source)
        at org.apache.camel.support.processor.validation.SchemaReader.createSchemaFactory(SchemaReader.java:184)
        at org.apache.camel.support.processor.validation.SchemaReader.getSchemaFactory(SchemaReader.java:157)
        at org.apache.camel.support.processor.validation.SchemaReader.createSchema(SchemaReader.java:198)
        at org.apache.camel.support.processor.validation.SchemaReader.loadSchema(SchemaReader.java:89)
        at org.apache.camel.component.validator.ValidatorEndpoint.createProducer(ValidatorEndpoint.java:121)
```

https://bugs.openjdk.java.net/browse/JDK-8200177
https://stackoverflow.com/questions/58374278/org-xml-sax-saxnotrecognizedexception-property-http-javax-xml-xmlconstants-p

Removing the xerces implementation allows the application to utilize the appropriate implementations that are now included with the JRE/JDK.

I also updated LFH connect's camel dependency from 3.4 to 3.7.1.

Note: I was able to determine which library "pulled' in xerces using the `./gradlew dependencies` command.

resolves #418 
