### PR TITLE
Reduce Test Case Execution Time

### DIFF
--- a/src/test/java/com/linuxforhealth/connect/builder/RouteTestSupport.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/RouteTestSupport.java
@@ -8,14 +8,17 @@ package com.linuxforhealth.connect.builder;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.language.ConstantExpression;
 import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import com.linuxforhealth.connect.support.TestUtils;
@@ -229,12 +232,18 @@ abstract class RouteTestSupport extends CamelTestSupport {
      */
     @BeforeEach
     protected void configureContext() throws Exception {
+        if (isCreateCamelContextPerClass() && context.isStarted()) {
+            return;
+        }
         context.start();
         fluentTemplate.start();
     }
 
     @AfterEach
     protected void stopContext() {
+        if (isCreateCamelContextPerClass()) {
+            return;
+        }
         fluentTemplate.stop();
         context.stop();
     }


### PR DESCRIPTION
This PR updates the HL7v2 and ETL route test cases to reduce processing time (locally at least) from approximately 26 seconds to 10 seconds.

Changes include:
- mocking the "store and notify route" in the HL7 test case. This was affected by the recent HL7v2/NAACR PR Merge
- updated the ETL Route to use a Camel Context per class rather than method/test case.

The latter change required some updates to setup/teardown methods since our RouteTestSupport "helper class" is extending the provided CamelTestSupport class.

resolves #425 