### PR TITLE
Test Case Performance Issue

### DIFF
--- a/src/test/java/com/linuxforhealth/connect/builder/Hl7v2FHIRConverterRouteBuilderTest.java
+++ b/src/test/java/com/linuxforhealth/connect/builder/Hl7v2FHIRConverterRouteBuilderTest.java
@@ -5,7 +5,7 @@
  */
 package com.linuxforhealth.connect.builder;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Assertions;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Properties;
@@ -26,6 +26,7 @@ public class Hl7v2FHIRConverterRouteBuilderTest extends RouteTestSupport {
 
   private MockEndpoint mockFHIREndpoint;
   private MockEndpoint mockStoreAndNotify;
+  private MockEndpoint mockErrorEndpoint;
 
 
   Properties props = null;
@@ -54,6 +55,9 @@ public class Hl7v2FHIRConverterRouteBuilderTest extends RouteTestSupport {
         FhirR4RouteBuilder.EXTERNAL_FHIR_ROUTE_URI, "mock:toExternalFhirServers");
     mockStoreAndNotify = mockProducerEndpoint(Hl7v2RouteBuilder.ROUTE_ID,
         LinuxForHealthRouteBuilder.STORE_AND_NOTIFY_CONSUMER_URI, "mock:storeAndNotify");
+    mockErrorEndpoint = mockProducerEndpoint(Hl7v2RouteBuilder.ROUTE_ID,
+        LinuxForHealthRouteBuilder.ERROR_CONSUMER_URI, "mock:error");
+
     super.configureContext();
   }
 
@@ -85,15 +89,15 @@ public class Hl7v2FHIRConverterRouteBuilderTest extends RouteTestSupport {
         .to("netty:tcp://localhost:2576?sync=true&encoders=#hl7encoder&decoders=#hl7decoder")
         .withBody(testMessage).send();
 
-    assertTrue(!mockFHIREndpoint.getExchanges().isEmpty(), "mockFHIREndpoint should not be empty");
-    String actualJson = mockFHIREndpoint.getExchanges().get(0).getIn().getBody(String.class);
-    assertTrue(StringUtils.contains(actualJson, "\"resourceType\":\"Bundle\""),
+    Assertions.assertFalse(mockFHIREndpoint.getExchanges().isEmpty(), "mockFHIREndpoint should not be empty");
+    String actualJson = (mockFHIREndpoint.getExchanges().get(0).getIn().getBody(String.class));
+    Assertions.assertTrue(StringUtils.contains(actualJson, "\"resourceType\":\"Bundle\""),
         "Output not expected");
 
-    assertTrue(!mockStoreAndNotify.getExchanges().isEmpty(),
+    Assertions.assertFalse(mockStoreAndNotify.getExchanges().isEmpty(),
         "mockStoreAndNotify should not be empty");
     String fhirResource = mockStoreAndNotify.getExchanges().get(1).getIn().getBody(String.class);
-    assertTrue(StringUtils.contains(fhirResource, "\"resourceType\":\"Bundle\""),
+    Assertions.assertTrue(StringUtils.contains(fhirResource, "\"resourceType\":\"Bundle\""),
         "Output not expected");
 
     assertMockEndpointsSatisfied();
@@ -123,7 +127,7 @@ public class Hl7v2FHIRConverterRouteBuilderTest extends RouteTestSupport {
         .to("netty:tcp://localhost:2576?sync=true&encoders=#hl7encoder&decoders=#hl7decoder")
         .withBody(testMessage).send();
 
-    assertTrue(mockFHIREndpoint.getExchanges().isEmpty(), "mockFHIREndpoint should  be empty");
+    Assertions.assertTrue(mockFHIREndpoint.getExchanges().isEmpty(), "mockFHIREndpoint should  be empty");
 
     assertMockEndpointsSatisfied(); // Verifies if input is equal to output
 
@@ -156,7 +160,7 @@ public class Hl7v2FHIRConverterRouteBuilderTest extends RouteTestSupport {
         .to("netty:tcp://localhost:2576?sync=true&encoders=#hl7encoder&decoders=#hl7decoder")
         .withBody(testMessage).send();
 
-    assertTrue(mockFHIREndpoint.getExchanges().isEmpty(), "mockFHIREndpoint should  be empty");
+    Assertions.assertTrue(mockFHIREndpoint.getExchanges().isEmpty(), "mockFHIREndpoint should  be empty");
 
     assertMockEndpointsSatisfied(); // Verifies if input is equal to output
 


### PR DESCRIPTION
This PR updates the HL7 -> FHIR Converter test cases to address a performance issue. The "error" test case took >= 30 seconds to process due to a missing mock endpoint.  After adding the mock endpoint to the test setup, the tests execute in a reasonable amount of time.

The "hint" that we missed mocking an endpoint is in the logs:
```
15:48:44.013 [Camel (camel-2) thread #137 - NettyConsumerExecutorGroup] WARN  o.a.c.p.FatalFallbackErrorHandler - \--> New exception on exchangeId: 81B3A2F6ED43926-0000000000000003
org.apache.camel.component.direct.DirectConsumerNotAvailableException: No consumers available on endpoint: direct://error. Exchange[81B3A2F6ED43926-0000000000000003]
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:76)
```

Before
<img width="460" alt="test-cases-before" src="https://user-images.githubusercontent.com/39178401/109224986-af967f00-778a-11eb-9b51-b6bebfd3dc02.png">

After
<img width="465" alt="test-cases-after" src="https://user-images.githubusercontent.com/39178401/109225005-b45b3300-778a-11eb-8344-4390f5c96090.png">
