### PR TITLE
X12 Route External Producer

### DIFF
--- a/container-support/compose/docker-compose.pi.yml
+++ b/container-support/compose/docker-compose.pi.yml
@@ -20,6 +20,7 @@ services:
       LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS: "nats-server:4222"
       LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
       LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
+      LFH_CONNECT_X12_EXTERNAL_URI: "mock:x-12"
     depends_on:
       - "kafka"
       - "nats-server"

--- a/container-support/compose/docker-compose.server.yml
+++ b/container-support/compose/docker-compose.server.yml
@@ -12,6 +12,7 @@ services:
       LFH_CONNECT_MESSAGING_SUBSCRIBE_HOSTS: "nats-server:4222"
       LFH_CONNECT_ORTHANC_SERVER_URI: "http://orthanc:8042/instances"
       LFH_CONNECT_DATASTORE_BROKERS: "kafka:9092"
+      LFH_CONNECT_X12_EXTERNAL_URI: "mock:x-12"
     depends_on:
       - "kafka"
       - "nats-server"


### PR DESCRIPTION
This PR adds the LFH_CONNECT_X12_EXTERNAL_URI environment variable to the compose server and pi profiles. The corresponding lfh.connect.x12.external.uri property existed prior to this PR. I'm just adding the environment variable in for documentation and consistency. The environment variable is currently set to a default value, "mock:x-12". This can be overriden by setting the environment variable in the current session or specifying a different value in the compose file.

I tested this change with the server profile by overriding. The screenshot below shows the x12 request and the response from the x12 genapp service using `LFH_CONNECT_X12_EXTERNAL_URI=http://localhost:8080/x12", which is my local location for the service.

<img width="1104" alt="lfh-x12-post" src="https://user-images.githubusercontent.com/39178401/109248675-390e7700-77b4-11eb-97c1-91805f5001ed.png">
