### PR TITLE
X12 Route - Support Single Transaction/Functional Group

### DIFF
--- a/src/main/java/com/linuxforhealth/connect/builder/X12RouteBuilder.java
+++ b/src/main/java/com/linuxforhealth/connect/builder/X12RouteBuilder.java
@@ -65,6 +65,7 @@ public class X12RouteBuilder extends BaseRouteBuilder {
         .post()
         .route()
         .routeId(X12_REST_ROUTE_ID)
+        .setProperty(ORIGINAL_MESSAGE_PROPERTY, simple("${body}"))
         .unmarshal().json(JsonLibrary.Jackson)
         .setBody(jsonpath("x12"))
         .validate(e -> e.getIn().getBody(String.class).length() > ISA_SEGMENT_LENGTH)
@@ -78,34 +79,15 @@ public class X12RouteBuilder extends BaseRouteBuilder {
         .setProperty("lineSeparator", simple("${body.substring(105,106)}"))
         .log(LoggingLevel.DEBUG, logger, "Line Separator to ${exchangeProperty.lineSeparator}")
         .log(LoggingLevel.DEBUG, logger, "Completed parsing X12 Delimiters")
-        .split(bean(X12ParserUtil.class,
-                "split(${body}, ${exchangeProperty.fieldDelimiter}, ${exchangeProperty.lineSeparator})"),
-                new LFHMultiResultStrategy())
-            .stopOnException()
-            .streaming()
-            .to(PROCESS_X12_TRANSACTION_URI)
-        .end();
-
-        from(PROCESS_X12_TRANSACTION_URI)
-        .routeId(X12_TRANSACTION_ROUTE_ID)
         .setHeader("X12MessageType", bean(X12ParserUtil.class,
-                "getX12MessageType(${body}, ${exchangeProperty.fieldDelimiter}, ${exchangeProperty.lineSeparator})"))
-        .log(LoggingLevel.DEBUG, logger, "Processing X12 Transaction ${header.X12MessageType}")
-        .setProperty(ORIGINAL_MESSAGE_PROPERTY, simple("${body}"))
+            "getX12MessageType(${body}, ${exchangeProperty.fieldDelimiter}, ${exchangeProperty.lineSeparator})"))
         .process(new MetaDataProcessor(routePropertyNamespace))
-        .id(METADATA_PROCESSOR_ID)
         .to(LinuxForHealthRouteBuilder.STORE_AND_NOTIFY_CONSUMER_URI)
         .removeHeaders("*")
         .setHeader("Accept", constant("application/json"))
         .setHeader(Exchange.HTTP_METHOD, constant("POST"))
         .setHeader(Exchange.CONTENT_TYPE, constant(ContentType.APPLICATION_JSON))
-        .process(exchange -> {
-            String originalMessage = exchange.getProperty(ORIGINAL_MESSAGE_PROPERTY, String.class);
-            originalMessage = originalMessage.trim();
-            JSONObject json = new JSONObject();
-            json.put("x12", originalMessage);
-            exchange.getIn().setBody(json.toString().trim());
-        })
+        .setBody(simple("${exchangeProperty.originalMessage}"))
         .to("{{lfh.connect.x12.external.uri}}");
     }
 }

--- a/src/main/java/com/linuxforhealth/connect/support/LFHMultiResultStrategy.java
+++ b/src/main/java/com/linuxforhealth/connect/support/LFHMultiResultStrategy.java
@@ -27,7 +27,7 @@ public class LFHMultiResultStrategy implements AggregationStrategy {
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
 
         if (oldExchange == null) {
-            JSONObject newResult = new JSONObject(newExchange.getIn().getBody(String.class));
+            JSONObject newResult = new JSONObject(new String(newExchange.getIn().getBody(byte[].class)));
             JSONArray results = new JSONArray(Collections.singletonList(newResult));
             newExchange.getIn().setBody(results.toString(), String.class);
             return newExchange;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -110,6 +110,7 @@ lfh.connect.datastore.get.timeout.milliseconds=500
 
 # LinuxForHealth messaging
 lfh.connect.bean.nats=org.apache.camel.component.nats.NatsComponent
+lfh.connect.messaging.nats.ssl=true
 lfh.connect.messaging.response.uri=nats:EVENTS.responses?servers=localhost:4222&secure=true&sslContextParameters=#sslContextParameters
 lfh.connect.messaging.error.uri=nats:EVENTS.errors?servers=localhost:4222&secure=true&sslContextParameters=#sslContextParameters
 lfh.connect.messaging.subscribe.subject=lfh-events


### PR DESCRIPTION
This PR updates the X12 route to support a single transaction/functional group. The previous code which featured a x12 transaction splitter also returned an aggregate response which causes issues with transaction processing. Additionally, LFH has been streamlined to support a single external endpoint per route, so this PR aligns the X12 route with our overall approach.

To test this issue I configured an environment where the X12 route on LFH stack "A" is integrated with the X12 route on LFH stack "B". LFH stack "B" integrates with a mock X12 service that returns a valid x12 transaction response.

270 Request
```
{"x12": "ISA*00*          *00*          *ZZ*890069730      *ZZ*154663145      *200929*1705*|*00501*000000001*0*T*:~GS*HS*890069730*154663145*20200929*1705*0001*X*005010X279A1~ST*270*0001*005010X279A1~BHT*0022*13*10001234*20200929*1319~HL*1**20*1~NM1*PR*2*UNIFIED INSURANCE CO*****PI*842610001~HL*2*1*21*1~NM1*1P*2*DOWNTOWN MEDICAL CENTER*****XX*2868383243~HL*3*2*22*0~TRN*1*1*1453915417~NM1*IL*1*PUG*LOUIS****MI*11122333301~DMG*D8*19690906~DTP*291*D8*20200101~EQ*30~SE*13*0001~GE*1*0001~IEA*1*000010216~"}
```

271 Request
```
{
    "x12": "ISA*00*          *00*          *ZZ*890069730      *ZZ*154663145      *200929*1705*|*00501*000000001*0*T*:~GS*HS*890069730*154663145*20200929*1705*0001*X*005010X279A1~ST*271*4321*005010X279A1~BHT*0022*11*10001234*20060501*1319~HL*1**20*1~NM1*PR*2*ABC COMPANY*****PI*842610001~HL*2*1*21*1~NM1*1P*2*BONE AND JOINT CLINIC*****SV*2000035~HL*3*2*22*0~TRN*2*1453915417*9877281234~NM1*IL*1*PUG*LOUIS****MI*11122333301~DMG*D8*19690906*~DTP*346*D8*20060101~EB*1**30**GOLD 123 PLAN~EB*L~EB*1**1>33>35>47>86>88>98>AL>MH>UC~EB*B**1>33>35>47>86>88>98>AL>MH>UC*HM*GOLD 123 PLAN*27*10*****Y~EB*B**1>33>35>47>86>88>98>AL>MH>UC*HM*GOLD 123 PLAN*27*30*****N~LS*2120~NM1*P3*1*JONES*MARCUS****SV*0202034~LE*2120~SE*20*4321~",
    "x12_transaction_code": "271"
}
```


